### PR TITLE
Change volume class to volume storage

### DIFF
--- a/custom_components/victron/manifest.json
+++ b/custom_components/victron/manifest.json
@@ -16,5 +16,5 @@
     "@sfstar"
   ],
   "iot_class": "local_polling",
-  "version": "0.0.1"
+  "version": "0.0.11"
 }

--- a/custom_components/victron/manifest.json
+++ b/custom_components/victron/manifest.json
@@ -1,20 +1,20 @@
 {
   "domain": "victron",
   "name": "victron",
+  "codeowners": [
+    "@sfstar"
+  ],
   "config_flow": true,
-  "integration_type": "hub",
+  "dependencies": [],
   "documentation": "https://github.com/sfstar/hass-victron",
+  "homekit": {},
+  "integration_type": "hub",
+  "iot_class": "local_polling",
   "issue_tracker": "https://github.com/sfstar/hass-victron/issues",
   "requirements": [
     "pymodbus==3.1.1"
   ],
   "ssdp": [],
-  "zeroconf": [],
-  "homekit": {},
-  "dependencies": [],
-  "codeowners": [
-    "@sfstar"
-  ],
-  "iot_class": "local_polling",
-  "version": "0.0.11"
+  "version": "0.0.11",
+  "zeroconf": []
 }

--- a/custom_components/victron/sensor.py
+++ b/custom_components/victron/sensor.py
@@ -97,7 +97,7 @@ def determine_victron_device_class(name, unit):
     elif unit in [member.value for member in UnitOfTemperature]:
         return  SensorDeviceClass.TEMPERATURE
     elif unit in [member.value for member in UnitOfVolume]:
-        return SensorDeviceClass.VOLUME # Perhaps change this to water if only water is measured in volume units
+        return SensorDeviceClass.VOLUME_STORAGE # Perhaps change this to water if only water is measured in volume units
     elif unit in [member.value for member in UnitOfSpeed]:
         if "meteo" in name:
             return SensorDeviceClass.WIND_SPEED


### PR DESCRIPTION
Tank based entities have volume based entities.
However, these entities should be storage based instead of consumption based.
This PR should address (at least in part) issue #62