### PR TITLE
Bump pymodbus to version 3.4.1

### DIFF
--- a/custom_components/victron/manifest.json
+++ b/custom_components/victron/manifest.json
@@ -12,7 +12,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/sfstar/hass-victron/issues",
   "requirements": [
-    "pymodbus==3.1.1"
+    "pymodbus==3.4.1"
   ],
   "ssdp": [],
   "version": "0.0.11",


### PR DESCRIPTION
HA Core has been updated to pymodbus library version 3.4.1.
This PR aligns the pymodbus versions so that core modbus integration and this integration remain interoperable.