### PR TITLE
Bump pymodbus 3.5.1 for 2023.9 patch compatibility

### DIFF
--- a/custom_components/victron/coordinator.py
+++ b/custom_components/victron/coordinator.py
@@ -54,7 +54,7 @@ class victronEnergyDeviceUpdateCoordinator(DataUpdateCoordinator):
         """Get the latest data from victron"""
         self.logger.debug("Fetching victron data")
         self.logger.debug(self.decodeInfo)
-        
+
         parsed_data = OrderedDict()
         unavailable_entities = OrderedDict()
 
@@ -72,7 +72,7 @@ class victronEnergyDeviceUpdateCoordinator(DataUpdateCoordinator):
                         full_key = str(unit) + "." + key
                         # self.data["data"][full_key] = None
                         unavailable_entities[full_key] = False
-                        
+
                     _LOGGER.warning(f"no valid data returned for entities of slave: {unit} (if the device continues to no longer update) check if the device was physically removed. Before opening an issue please force a rescan to attempt to resolve this issue")
                 else:
                     parsed_data = OrderedDict(list(parsed_data.items()) + list(self.parse_register_data(data, register_info_dict[name], unit).items()))
@@ -88,7 +88,7 @@ class victronEnergyDeviceUpdateCoordinator(DataUpdateCoordinator):
 
     def parse_register_data(self, buffer: ReadHoldingRegistersResponse, registerInfo: OrderedDict(str, RegisterInfo), unit: int) -> dict:
         decoder = BinaryPayloadDecoder.fromRegisters(
-        buffer.registers, byteorder=Endian.Big
+        buffer.registers, byteorder=Endian.BIG
         )
         decoded_data  = OrderedDict()
         for key,value in registerInfo.items():

--- a/custom_components/victron/manifest.json
+++ b/custom_components/victron/manifest.json
@@ -12,7 +12,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/sfstar/hass-victron/issues",
   "requirements": [
-    "pymodbus>=3.3.1"
+    "pymodbus>=3.5.1"
   ],
   "ssdp": [],
   "version": "0.0.11",

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
     "name": "Victron GX modbus TCP",
     "render_readme": true,
-    "homeassistant": "2023.2.0",
+    "homeassistant": "2023.9.1",
     "hacs": "1.28.4"
   }


### PR DESCRIPTION
Bump pymodbus and ha core minimum version requirement due to breaking core pymodbus patch (endian spelling)