### PR TITLE
hub.py: TimeOut for Read Holding Register

### DIFF
--- a/custom_components/victron/hub.py
+++ b/custom_components/victron/hub.py
@@ -34,10 +34,13 @@ class VictronHub:
         with self._lock:
             kwargs = {"slave": int(unit)} if unit else {}
             try:
-                readreg = self._client.read_holding_registers(address, count, **kwargs)
-            except TimeOutException as ex::
-                readreg = ex
-            return readreg
+                result = self._client.read_holding_registers(address, count, **kwargs)
+                if result.isError():
+                    _LOGGER.debug("result is error for unit: " + str(unit) + " address: " + str(address) + " count: " + str(count))
+                else:
+                    return result
+            except Exception  as e:  # pylint: disable=broad-except
+                _LOGGER.error(e)
 
     def calculate_register_count(self, registerInfoDict: OrderedDict):
         first_key = next(iter(registerInfoDict))

--- a/custom_components/victron/hub.py
+++ b/custom_components/victron/hub.py
@@ -33,7 +33,11 @@ class VictronHub:
         """Read holding registers."""
         with self._lock:
             kwargs = {"slave": int(unit)} if unit else {}
-            return self._client.read_holding_registers(address, count, **kwargs)
+            try:
+                readreg = self._client.read_holding_registers(address, count, **kwargs)
+            except TimeOutException as ex::
+                readreg = ex
+            return readreg
 
     def calculate_register_count(self, registerInfoDict: OrderedDict):
         first_key = next(iter(registerInfoDict))


### PR DESCRIPTION
if you have a device that is temporarily offline the it runs in a timeout and the whole plugin stops working
This try/except block will prevent that