### PR TITLE
add mppt starting state

### DIFF
--- a/custom_components/victron/const.py
+++ b/custom_components/victron/const.py
@@ -444,6 +444,7 @@ class solarcharger_state(Enum):
     STORAGE = 6
     EQUALIZE = 7
     OTHER_HUB_1 = 11
+    STARTING = 245
     EXTERNAL_CONTROL = 252
 
 class solarcharger_equalization_pending(Enum):


### PR DESCRIPTION
See https://community.victronenergy.com/questions/153855/what-is-mppt-state-245.html


Fixes following error:

```pytb
2023-12-12 07:45:55.618 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 243, in _handle_refresh_interval
    await self._async_refresh(log_failures=True, scheduled=True)
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 399, in _async_refresh
    self.async_update_listeners()
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 182, in async_update_listeners
    update_callback()
  File "/config/custom_components/victron/sensor.py", line 157, in _handle_coordinator_update
    self._attr_native_value = self.entity_type.decodeEnum(data).name.split("_DUPLICATE")[0]
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/enum.py", line 712, in __call__
    return cls.__new__(cls, value)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/enum.py", line 1135, in __new__
    raise ve_exc
ValueError: 245.0 is not a valid solarcharger_state
```