### PR TITLE
DRAFT: Add registers that were introduced in victron gx version 3.20

### DIFF
--- a/custom_components/victron/const.py
+++ b/custom_components/victron/const.py
@@ -555,8 +555,11 @@ pvinverter_registers = {
     "pvinverter_L2_energy_forward_total": RegisterInfo(1048, UINT32, UnitOfEnergy.KILO_WATT_HOUR, 100),
     "pvinverter_L3_energy_forward_total": RegisterInfo(1050, UINT32, UnitOfEnergy.KILO_WATT_HOUR, 100),
     "pvinverter_power_total": RegisterInfo(1052, INT32, UnitOfPower.WATT),
-    "pvinverter_power_max_capacity": RegisterInfo(1054, UINT32, UnitOfPower.KILO_WATT),
-    "pvinverter_powerlimit": RegisterInfo(register=1056, dataType=UINT32, unit=UnitOfPower.WATT, entityType=SliderWriteType("AC", False))
+    "pvinverter_power_max_capacity": RegisterInfo(1054, UINT32, UnitOfPower.WATT),
+    "pvinverter_powerlimit": RegisterInfo(register=1056, dataType=UINT32, unit=UnitOfPower.WATT, entityType=SliderWriteType("AC", False)),
+    "pvinverter_L1_power": RegisterInfo(1058, UINT32, UnitOfPower.WATT),
+    "pvinverter_L2_power": RegisterInfo(1060, UINT32, UnitOfPower.WATT),
+    "pvinverter_L3_power": RegisterInfo(1062, UINT32, UnitOfPower.WATT) 
 }
 
 motordrive_registers = {


### PR DESCRIPTION
Please note that due to the nature of these changes entire register sets can fail to retrieve/be discovered if you are running an older version of the gx software.