### PR TITLE
Change gps altitude register from meters per seconds to meters

### DIFF
--- a/custom_components/victron/const.py
+++ b/custom_components/victron/const.py
@@ -7,6 +7,7 @@ from homeassistant.const import (
     UnitOfElectricPotential,
     UnitOfElectricCurrent,
     UnitOfFrequency,
+    UnitOfLength,
     UnitOfTime,
     REVOLUTIONS_PER_MINUTE,
     UnitOfIrradiance,
@@ -615,7 +616,7 @@ gps_registers = {
     "gps_speed": RegisterInfo(2805, UINT16, UnitOfSpeed.METERS_PER_SECOND, 100),
     "gps_fix": RegisterInfo(register=2806, dataType=UINT16, entityType=BoolReadEntityType()),
     "gps_numberofsatellites": RegisterInfo(2807, UINT16),
-    "gps_altitude": RegisterInfo(2808, INT32, UnitOfSpeed.METERS_PER_SECOND, 10)
+    "gps_altitude": RegisterInfo(2808, INT32, UnitOfLength.METERS, 10)
 }
 
 class ess_batterylife_state(Enum):


### PR DESCRIPTION
to reflect the new specsheet that was published we need to change the unit of measurement from meters per seconds to meters for gps altitude register. Solves #28 

Unfortunatly it isn't possible to migrate the unit for historical data.
So users should go to "developer tools -> statistics" and press "Fix Issue" to ensure long term statistics are generated again.