### PR TITLE
Only assign device class battery to entities measured in percentages

### DIFF
--- a/custom_components/victron/sensor.py
+++ b/custom_components/victron/sensor.py
@@ -83,8 +83,10 @@ async def async_setup_entry(
     async_add_entities(entities, True)
 
 def determine_victron_device_class(name, unit):
-    if unit == PERCENTAGE:
+    if unit == PERCENTAGE and "soc" in name:
         return SensorDeviceClass.BATTERY
+    elif unit == PERCENTAGE:
+        return None #Device classes aren't supported for voltage deviation and other % based entities that do not report SOC, moisture or humidity
     elif unit in [member.value for member in UnitOfPower]:
         return SensorDeviceClass.POWER
     elif unit in [member.value for member in UnitOfEnergy]:


### PR DESCRIPTION
Battery soc in general overview is incorrectly reporting 0% due to non SOC related entities getting assigned with the battery device class.
Allowing them to be selected by HA as the devices current SOC to be displayed #130.
This PR only assigns SOC entities the battery device class and sets no device class for other percentage based entities that aren't of type moisture, humidity or state of charge.