### PR TITLE
add ess mode 0

### DIFF
--- a/custom_components/victron/const.py
+++ b/custom_components/victron/const.py
@@ -635,8 +635,9 @@ class ess_batterylife_state(Enum):
     BL_DISABLED_LOC_SOC_RECHARGE = 12
 
 class ess_mode(Enum):
-    ESS_PHASE_COMPENSATION = 1
-    ESS_NO_PHASE_COMPENSATION = 2
+    SELF_CONSUMPTION_WITH_BATTERY_LIFE = 0
+    SELF_CONSUMPTION = 1
+    KEEP_CHARGED = 2
     EXTERNAL_CONTROL = 3
 
 settings_ess_registers = {


### PR DESCRIPTION
base the ess mode values on attributes csv file from victron instead of xlsx.
This PR addresses: #44.
The values that are present in the attributes.csv also better match the values that are selecteable in the GX device itself:
<img width="699" alt="attributes_ess_mode" src="https://github.com/sfstar/hass-victron/assets/6717280/129c6436-670d-480b-8134-b87ee72f8ede">

