### PR TITLE
add solarcharger state 245 as wake up

### DIFF
--- a/custom_components/victron/const.py
+++ b/custom_components/victron/const.py
@@ -445,6 +445,7 @@ class solarcharger_state(Enum):
     STORAGE = 6
     EQUALIZE = 7
     OTHER_HUB_1 = 11
+    WAKE_UP = 245
     EXTERNAL_CONTROL = 252
 
 class solarcharger_equalization_pending(Enum):


### PR DESCRIPTION
use the bluesolar hex protocol to detemine status code 245 meaning since it is not documented in the official xlsx.
Addresses: #178 