### PR TITLE
split devices by a combination of unit id and name

### DIFF
--- a/custom_components/victron/binary_sensor.py
+++ b/custom_components/victron/binary_sensor.py
@@ -115,7 +115,7 @@ class VictronBinarySensor(CoordinatorEntity, BinarySensorEntity):
         """Return the device info."""
         return entity.DeviceInfo(
             identifiers={
-                (DOMAIN, self.unique_id.split('_')[0])
+                (DOMAIN, self.unique_id.split('_')[0] + self.unique_id.split('_')[1])
             },
             name=self.unique_id.split('_')[1],
             model=self.unique_id.split('_')[0],

--- a/custom_components/victron/button.py
+++ b/custom_components/victron/button.py
@@ -110,7 +110,7 @@ class VictronBinarySensor(CoordinatorEntity, ButtonEntity):
         """Return the device info."""
         return entity.DeviceInfo(
             identifiers={
-                (DOMAIN, self.unique_id.split('_')[0])
+                (DOMAIN, self.unique_id.split('_')[0] + self.unique_id.split('_')[1])
             },
             name=self.unique_id.split('_')[1],
             model=self.unique_id.split('_')[0],

--- a/custom_components/victron/number.py
+++ b/custom_components/victron/number.py
@@ -239,7 +239,7 @@ class VictronNumber(NumberEntity):
         """Return the device info."""
         return entity.DeviceInfo(
             identifiers={
-                (DOMAIN, self.unique_id.split('_')[0])
+                (DOMAIN, self.unique_id.split('_')[0] + self.unique_id.split('_')[1])
             },
             name=self.unique_id.split('_')[1],
             model=self.unique_id.split('_')[0],

--- a/custom_components/victron/select.py
+++ b/custom_components/victron/select.py
@@ -144,7 +144,7 @@ class VictronSelect(CoordinatorEntity, SelectEntity):
         """Return the device info."""
         return entity.DeviceInfo(
             identifiers={
-                (DOMAIN, self.unique_id.split('_')[0])
+                (DOMAIN, self.unique_id.split('_')[0] + self.unique_id.split('_')[1])
             },
             name=self.unique_id.split('_')[1],
             model=self.unique_id.split('_')[0],

--- a/custom_components/victron/switch.py
+++ b/custom_components/victron/switch.py
@@ -120,7 +120,7 @@ class VictronSwitch(CoordinatorEntity, SwitchEntity):
         """Return the device info."""
         return entity.DeviceInfo(
             identifiers={
-                (DOMAIN, self.unique_id.split('_')[0])
+                (DOMAIN, self.unique_id.split('_')[0] + self.unique_id.split('_')[1])
             },
             name=self.unique_id.split('_')[1],
             model=self.unique_id.split('_')[0],


### PR DESCRIPTION
splitting devices by name will end the flip flopping of device names when different type register set namings are used