### PR TITLE
cleanup the device seperation obsolete code

### DIFF
--- a/custom_components/victron/binary_sensor.py
+++ b/custom_components/victron/binary_sensor.py
@@ -45,12 +45,6 @@ async def async_setup_entry(
             for register_name, registerInfo in register_info_dict[name].items():
                 _LOGGER.debug("unit == " + str(slave) + " registerLedger == " + str(registerLedger) + " registerInfo ")
 
-                #VE.CAN device zero is present under unit 100. This seperates non system / settings entities into the seperate can device
-                # if slave == 100 and not register_name.startswith(("settings", "system")) :
-                #     actual_id = 0
-                # else:
-                #     actual_id = slave
-
                 if isinstance(registerInfo.entityType, BoolReadEntityType):
                     description = VictronEntityDescription(
                         key=register_name,

--- a/custom_components/victron/button.py
+++ b/custom_components/victron/button.py
@@ -39,11 +39,6 @@ async def async_setup_entry(
                 if not config_entry.options[CONF_ADVANCED_OPTIONS]:
                         continue
 
-                # if slave == 100 and not register_name.startswith(("settings", "system")) :
-                #     actual_id = 0
-                # else:
-                #     actual_id = slave
-
                 if isinstance(registerInfo.entityType, ButtonWriteType):
                     description = VictronEntityDescription(
                         key=register_name,

--- a/custom_components/victron/hub.py
+++ b/custom_components/victron/hub.py
@@ -64,9 +64,6 @@ class VictronHub:
             #VE.CAN device zero is present under unit 100. This seperates non system / settings entities into the seperate can device
                 if unit == 100 and not key.startswith(("settings", "system")) :
                     continue
-                #     actual_id = 0
-                # else:
-                #     actual_id = unit
 
                 try:
                     address = self.get_first_register_id(register_definition)

--- a/custom_components/victron/number.py
+++ b/custom_components/victron/number.py
@@ -63,11 +63,6 @@ async def async_setup_entry(
                 for register_name, registerInfo in register_info_dict[name].items():
                     _LOGGER.debug("unit == " + str(slave) + " registerLedger == " + str(registerLedger) + " registerInfo ")
 
-                    # if slave == 100 and not register_name.startswith(("settings", "system")) :
-                    #     actual_id = 0
-                    # else:
-                    #     actual_id = slave
-
                     if isinstance(registerInfo.entityType, SliderWriteType):
                         description = VictronEntityDescription(
                             key=register_name,

--- a/custom_components/victron/select.py
+++ b/custom_components/victron/select.py
@@ -43,11 +43,6 @@ async def async_setup_entry(
                 for register_name, registerInfo in register_info_dict[name].items():
                     if isinstance(registerInfo.entityType, SelectWriteType):
                         _LOGGER.debug("unit == " + str(slave) + " registerLedger == " + str(registerLedger) + " registerInfo ")
-
-                        # if slave == 100 and not register_name.startswith(("settings", "system")) :
-                        #     actual_id = 0
-                        # else:
-                        #     actual_id = slave
                             
                         description = VictronEntityDescription(
                             key=register_name,

--- a/custom_components/victron/sensor.py
+++ b/custom_components/victron/sensor.py
@@ -56,12 +56,6 @@ async def async_setup_entry(
                 if config_entry.options[CONF_ADVANCED_OPTIONS]:
                     if not isinstance(registerInfo.entityType, ReadEntityType) or isinstance(registerInfo.entityType, BoolReadEntityType):
                         continue
-
-                #VE.CAN device zero is present under unit 100. This seperates non system / settings entities into the seperate can device
-                # if slave == 100 and not register_name.startswith(("settings", "system")) :
-                #     actual_id = 0
-                # else:
-                #     actual_id = slave
                     
                 description = VictronEntityDescription(
                     key=register_name,

--- a/custom_components/victron/switch.py
+++ b/custom_components/victron/switch.py
@@ -39,12 +39,6 @@ async def async_setup_entry(
                 for register_name, registerInfo in register_info_dict[name].items():
                     _LOGGER.debug("unit == " + str(slave) + " registerLedger == " + str(registerLedger) + " registerInfo ")
 
-                    #VE.CAN device zero is present under unit 100. This seperates non system / settings entities into the seperate can device
-                    # if slave == 100 and not register_name.startswith(("settings", "system")) :
-                    #     actual_id = 0
-                    # else:
-                    #     actual_id = slave
-
                     if isinstance(registerInfo.entityType, SwitchWriteType):
                         description = VictronEntityDescription(
                             key=register_name,


### PR DESCRIPTION
removes old testing code that is obsolete now that there is another way of seperating unit id 0 and 100 devices