### PR TITLE
Match Version Info in Hass with Version in Github

### DIFF
--- a/custom_components/victron/manifest.json
+++ b/custom_components/victron/manifest.json
@@ -15,6 +15,6 @@
     "pymodbus>=3.5.1"
   ],
   "ssdp": [],
-  "version": "0.0.11",
+  "version": "0.2.00",
   "zeroconf": []
 }


### PR DESCRIPTION
Match Version numbering in Hass to actual version. Was very confusing for me and i thought that i have a old version installed