### PR TITLE
correction of ev charger status (Manual, Auto, Scheduled)

### DIFF
--- a/custom_components/victron/const.py
+++ b/custom_components/victron/const.py
@@ -999,10 +999,12 @@ evcharger_productid_registers = {
     "evcharger_productid": RegisterInfo(3800, UINT16)
 }
 
+# *** correction by OK1BPN
 class evcharger_mode(Enum):
-    AC_INPUT_1 = 0
-    AC_OUTPUT = 1
-    AC_INPUT_2 = 2
+    MANUAL = 0
+    AUTO = 1
+    SCHEDULED = 2
+# *** end of correction
 
 class evcharger_status(Enum):
     DISCONNECTED = 0


### PR DESCRIPTION
Correction of very likely copu-paste error.

EV Charger mode has 3 statuses
Manual - manually can be switched ON regardless of any other

Auto - automatic mode, charger starts charging when enough solar power is available 

Scheduled - accordingly to defined scheduled window it switch on charger ON - similar to manul mode, solar power availability is irrelevant.