### PR TITLE
backport 2025.2 from remcom fork

### DIFF
--- a/custom_components/victron/coordinator.py
+++ b/custom_components/victron/coordinator.py
@@ -6,7 +6,13 @@ import logging
 
 from pymodbus.constants import Endian
 from pymodbus.payload import BinaryPayloadDecoder
-from pymodbus.pdu.register_read_message import ReadHoldingRegistersResponse
+
+import pymodbus
+
+if "3.7.0" <= pymodbus.__version__ <= "3.7.4":
+    from pymodbus.pdu.register_read_message import ReadHoldingRegistersResponse
+else:
+    from pymodbus.pdu.register_message import ReadHoldingRegistersResponse
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError

--- a/custom_components/victron/hub.py
+++ b/custom_components/victron/hub.py
@@ -31,15 +31,15 @@ class VictronHub:
         return None
 
     def write_register(self, unit, address, value):
-        with self._lock:
-            kwargs = {"slave": int(unit)} if unit else {}
-            return self._client.write_register(address, value, **kwargs)
+        slave = int(unit) if unit else 1
+        return self._client.write_register(address=address, value=value, slave=slave)
 
     def read_holding_registers(self, unit, address, count):
         """Read holding registers."""
-        with self._lock:
-            kwargs = {"slave": int(unit)} if unit else {}
-            return self._client.read_holding_registers(address, count, **kwargs)
+        slave = int(unit) if unit else 1
+        return self._client.read_holding_registers(
+            address=address, count=count, slave=slave
+        )
 
     def calculate_register_count(self, registerInfoDict: OrderedDict):
         first_key = next(iter(registerInfoDict))


### PR DESCRIPTION
As discussed with @remcom this PR will be the start of backporting fixes made on the remcom fork.
This pr limits itself to only the code necessarry to be able to run this integration on homeassistant 2025.2
This needs to be merged before 5 februari (release date of ha 2025.2)