### PR TITLE
Feature/clean typing linter

### DIFF
--- a/custom_components/victron/__init__.py
+++ b/custom_components/victron/__init__.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from .const import CONF_HOST, CONF_INTERVAL, CONF_PORT, DOMAIN, SCAN_REGISTERS
-from .coordinator import victronEnergyDeviceUpdateCoordinator as Coordinator
+from .coordinator import VictronEnergyDeviceUpdateCoordinator as Coordinator
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
@@ -52,7 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> Any:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(
         config_entry, PLATFORMS

--- a/custom_components/victron/base.py
+++ b/custom_components/victron/base.py
@@ -1,27 +1,27 @@
 """Module defines entity descriptions for Victron components."""
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from typing import Any, dataclass_transform
 
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.typing import StateType
 
 
-@dataclass
-class VictronBaseEntityDescription(EntityDescription):
+@dataclass_transform(frozen_default=True)
+class VictronBaseEntityDescription(EntityDescription):  # type: ignore[misc]
     """An extension of EntityDescription for Victron components."""
 
     @staticmethod
-    def lambda_func():
+    def lambda_func() -> Any:
         """Return an entitydescription."""
         return lambda data, slave, key: data["data"][str(slave) + "." + str(key)]
 
-    slave: int = None
+    slave: int | None = None
     value_fn: Callable[[dict], StateType] = lambda_func()
 
 
-@dataclass
+@dataclass_transform(frozen_default=True)
 class VictronWriteBaseEntityDescription(VictronBaseEntityDescription):
     """An extension of VictronBaseEntityDescription for writeable Victron components."""
 
-    address: int = None
+    address: float | None = None

--- a/custom_components/victron/binary_sensor.py
+++ b/custom_components/victron/binary_sensor.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
-from typing import cast
+from typing import Any, cast, dataclass_transform
 
 from homeassistant.components.binary_sensor import (
     DOMAIN as BINARY_SENSOR_DOMAIN,
@@ -19,7 +18,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .base import VictronBaseEntityDescription
 from .const import DOMAIN, BoolReadEntityType, register_info_dict
-from .coordinator import victronEnergyDeviceUpdateCoordinator
+from .coordinator import VictronEnergyDeviceUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,7 +30,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Victron energy binary sensor entries."""
     _LOGGER.debug("attempting to setup binary sensor entities")
-    victron_coordinator: victronEnergyDeviceUpdateCoordinator = hass.data[DOMAIN][
+    victron_coordinator: VictronEnergyDeviceUpdateCoordinator = hass.data[DOMAIN][
         config_entry.entry_id
     ]
     _LOGGER.debug(victron_coordinator.processed_data()["register_set"])
@@ -43,12 +42,12 @@ async def async_setup_entry(
         for name in registerLedger:
             for register_name, registerInfo in register_info_dict[name].items():
                 _LOGGER.debug(
-                    "unit == %s registerLedger == %s registerInfo",
+                    "unit == %s registerLedger == %s register_info",
                     slave,
                     registerLedger,
                 )
 
-                if isinstance(registerInfo.entityType, BoolReadEntityType):
+                if isinstance(registerInfo.entity_type, BoolReadEntityType):
                     description = VictronEntityDescription(
                         key=register_name,
                         name=register_name.replace("_", " "),
@@ -57,28 +56,28 @@ async def async_setup_entry(
                     _LOGGER.debug("composed description == %s", description)
                     descriptions.append(description)
 
-    entities = []
-    entity = {}
-    for description in descriptions:
-        entity = description
-        entities.append(VictronBinarySensor(victron_coordinator, entity))
+    entities = [
+        VictronBinarySensor(victron_coordinator, description)
+        for description in descriptions
+    ]
 
     async_add_entities(entities, True)
 
 
-@dataclass
+@dataclass_transform(frozen_default=True)
 class VictronEntityDescription(
-    BinarySensorEntityDescription, VictronBaseEntityDescription
+    BinarySensorEntityDescription,  # type: ignore[misc]
+    VictronBaseEntityDescription,
 ):
     """Describes victron sensor entity."""
 
 
-class VictronBinarySensor(CoordinatorEntity, BinarySensorEntity):
+class VictronBinarySensor(CoordinatorEntity, BinarySensorEntity):  # type: ignore[misc]
     """A binary sensor implementation for Victron energy device."""
 
     def __init__(
         self,
-        coordinator: victronEnergyDeviceUpdateCoordinator,
+        coordinator: VictronEnergyDeviceUpdateCoordinator,
         description: VictronEntityDescription,
     ) -> None:
         """Initialize the binary sensor."""
@@ -102,14 +101,14 @@ class VictronBinarySensor(CoordinatorEntity, BinarySensorEntity):
     def is_on(self) -> bool:
         """Return True if the binary sensor is on."""
         data = self.description.value_fn(
-            self.coordinator.processed_data(),
+            self.coordinator.processed_data(),  # type: ignore[call-arg]
             self.description.slave,
             self.description.key,
         )
         return cast(bool, data)
 
     @property
-    def available(self) -> bool:
+    def available(self) -> Any:
         """Return True if entity is available."""
         full_key = str(self.description.slave) + "." + self.description.key
         return self.coordinator.processed_data()["availability"][full_key]
@@ -120,6 +119,6 @@ class VictronBinarySensor(CoordinatorEntity, BinarySensorEntity):
         return entity.DeviceInfo(
             identifiers={(DOMAIN, self.unique_id.split("_")[0])},
             name=self.unique_id.split("_")[1],
-            model=self.unique_id.split("_")[0],
+            model=self.unique_id.split("_", maxsplit=1)[0],
             manufacturer="victron",
         )

--- a/custom_components/victron/button.py
+++ b/custom_components/victron/button.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
+from typing import Any, dataclass_transform
 
 from homeassistant.components.button import (
     DOMAIN as BUTTON_DOMAIN,
@@ -19,7 +19,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .base import VictronWriteBaseEntityDescription
 from .const import CONF_ADVANCED_OPTIONS, DOMAIN, ButtonWriteType, register_info_dict
-from .coordinator import victronEnergyDeviceUpdateCoordinator
+from .coordinator import VictronEnergyDeviceUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Victron energy binary sensor entries."""
     _LOGGER.debug("attempting to setup button entities")
-    victron_coordinator: victronEnergyDeviceUpdateCoordinator = hass.data[DOMAIN][
+    victron_coordinator: VictronEnergyDeviceUpdateCoordinator = hass.data[DOMAIN][
         config_entry.entry_id
     ]
     descriptions = []
@@ -41,14 +41,14 @@ async def async_setup_entry(
         for name in registerLedger:
             for register_name, registerInfo in register_info_dict[name].items():
                 _LOGGER.debug(
-                    "unit == %s registerLedger == %s registerInfo",
+                    "unit == %s registerLedger == %s register_info",
                     slave,
                     registerLedger,
                 )
                 if not config_entry.options[CONF_ADVANCED_OPTIONS]:
                     continue
 
-                if isinstance(registerInfo.entityType, ButtonWriteType):
+                if isinstance(registerInfo.entity_type, ButtonWriteType):
                     description = VictronEntityDescription(
                         key=register_name,
                         name=register_name.replace("_", " "),
@@ -59,28 +59,28 @@ async def async_setup_entry(
                     _LOGGER.debug("composed description == %s", description)
                     descriptions.append(description)
 
-    entities = []
-    entity = {}
-    for description in descriptions:
-        entity = description
-        entities.append(VictronBinarySensor(victron_coordinator, entity))
+    entities = [
+        VictronBinarySensor(victron_coordinator, description)
+        for description in descriptions
+    ]
 
     async_add_entities(entities, True)
 
 
-@dataclass
+@dataclass_transform(frozen_default=True)
 class VictronEntityDescription(
-    ButtonEntityDescription, VictronWriteBaseEntityDescription
+    ButtonEntityDescription,  # type: ignore[misc]
+    VictronWriteBaseEntityDescription,
 ):
     """Describes victron sensor entity."""
 
 
-class VictronBinarySensor(CoordinatorEntity, ButtonEntity):
+class VictronBinarySensor(CoordinatorEntity, ButtonEntity):  # type: ignore[misc]
     """A button implementation for Victron energy device."""
 
     def __init__(
         self,
-        coordinator: victronEnergyDeviceUpdateCoordinator,
+        coordinator: VictronEnergyDeviceUpdateCoordinator,
         description: VictronEntityDescription,
     ) -> None:
         """Initialize the sensor."""
@@ -106,7 +106,7 @@ class VictronBinarySensor(CoordinatorEntity, ButtonEntity):
         )
 
     @property
-    def available(self) -> bool:
+    def available(self) -> Any:
         """Return True if entity available."""
         full_key = str(self.description.slave) + "." + self.description.key
         return self.coordinator.processed_data()["availability"][full_key]
@@ -117,6 +117,6 @@ class VictronBinarySensor(CoordinatorEntity, ButtonEntity):
         return entity.DeviceInfo(
             identifiers={(DOMAIN, self.unique_id.split("_")[0])},
             name=self.unique_id.split("_")[1],
-            model=self.unique_id.split("_")[0],
+            model=self.unique_id.split("_", maxsplit=1)[0],
             manufacturer="victron",
         )

--- a/custom_components/victron/coordinator.py
+++ b/custom_components/victron/coordinator.py
@@ -8,6 +8,8 @@ import logging
 
 import pymodbus
 from pymodbus.constants import Endian
+
+# this import needs to be able to be completely removed if the preparation for 3.9.0 is done
 from pymodbus.payload import BinaryPayloadDecoder
 
 if "3.7.0" <= pymodbus.__version__ <= "3.7.4":

--- a/custom_components/victron/manifest.json
+++ b/custom_components/victron/manifest.json
@@ -15,6 +15,6 @@
     "pymodbus>=3.7.4"
   ],
   "ssdp": [],
-  "version": "v0.5.0",
+  "version": "v0.0.0",
   "zeroconf": []
 }

--- a/custom_components/victron/popBuffer.py
+++ b/custom_components/victron/popBuffer.py
@@ -1,0 +1,31 @@
+from const.py import UINT16, INT16, UINT32, INT32, STRING
+
+
+class PopBuffer:
+    """A buffer wrapper class that allows for positional awareness in buffer for decoding register data."""
+
+    def __init__(self, size):
+        self.buffer = [None] * size
+        self.size = size
+        self.position = 0
+
+    def getItemInBuffer(self, dataType):
+        """Get the item in the buffer."""
+        match dataType:
+            case UINT16:
+            # Handle UINT16
+            pass
+            case UINT32:
+            # Handle UINT32
+            pass
+            case INT16:
+            # Handle INT16
+            pass
+            case INT32:
+            # Handle INT32
+            pass
+            case _:
+            raise ValueError(f"Unsupported data type: {dataType}")
+        item = self.buffer[self.position]
+        self.position += 1
+        return item

--- a/custom_components/victron/popBuffer.py
+++ b/custom_components/victron/popBuffer.py
@@ -1,31 +1,42 @@
-from const.py import UINT16, INT16, UINT32, INT32, STRING
+"""popBuffer."""
+
+from typing import Any
 
 
 class PopBuffer:
     """A buffer wrapper class that allows for positional awareness in buffer for decoding register data."""
 
-    def __init__(self, size):
+    def __init__(self, size: int) -> None:
+        """Buffer wrapper class that allows for positional awareness in buffer for decoding register data.
+
+        :param size: Size of the buffer
+        """
         self.buffer = [None] * size
-        self.size = size
+        self.size: int = size
         self.position = 0
 
-    def getItemInBuffer(self, dataType):
-        """Get the item in the buffer."""
-        match dataType:
-            case UINT16:
-            # Handle UINT16
-            pass
-            case UINT32:
-            # Handle UINT32
-            pass
-            case INT16:
-            # Handle INT16
-            pass
-            case INT32:
-            # Handle INT32
-            pass
-            case _:
-            raise ValueError(f"Unsupported data type: {dataType}")
+    def get_item_in_buffer(self, data_type: Any) -> None:
+        """Get the item in the buffer.
+
+        :param data_type: buffer item
+        :return:
+        """
+        # TODO: decomment
+        # match data_type:
+        #     case UINT16:
+        #     # Handle UINT16
+        #         pass
+        #     case UINT32:
+        #     # Handle UINT32
+        #         pass
+        #     case INT16:
+        #     # Handle INT16
+        #         pass
+        #     case INT32:
+        #     # Handle INT32
+        #         pass
+        #     case _:
+        #         raise ValueError(f"Unsupported data type: {data_type}")
         item = self.buffer[self.position]
         self.position += 1
         return item

--- a/custom_components/victron/sensor.py
+++ b/custom_components/victron/sensor.py
@@ -1,7 +1,7 @@
 """Support for Victron energy sensors."""
 
-from dataclasses import dataclass
 import logging
+from typing import Any, dataclass_transform
 
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
@@ -37,7 +37,7 @@ from .const import (
     TextReadEntityType,
     register_info_dict,
 )
-from .coordinator import victronEnergyDeviceUpdateCoordinator
+from .coordinator import VictronEnergyDeviceUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ async def async_setup_entry(
 ) -> None:
     """Set up Victron energy sensor entries."""
     _LOGGER.debug("attempting to setup sensor entities")
-    victron_coordinator: victronEnergyDeviceUpdateCoordinator = hass.data[DOMAIN][
+    victron_coordinator: VictronEnergyDeviceUpdateCoordinator = hass.data[DOMAIN][
         config_entry.entry_id
     ]
     _LOGGER.debug(victron_coordinator.processed_data()["register_set"])
@@ -61,14 +61,14 @@ async def async_setup_entry(
         for name in registerLedger:
             for register_name, registerInfo in register_info_dict[name].items():
                 _LOGGER.debug(
-                    "unit == %s registerLedger == %s registerInfo",
+                    "unit == %s registerLedger == %s register_info",
                     slave,
                     registerLedger,
                 )
                 if config_entry.options[CONF_ADVANCED_OPTIONS]:
                     if not isinstance(
-                        registerInfo.entityType, ReadEntityType
-                    ) or isinstance(registerInfo.entityType, BoolReadEntityType):
+                        registerInfo.entity_type, ReadEntityType
+                    ) or isinstance(registerInfo.entity_type, BoolReadEntityType):
                         continue
 
                 description = VictronEntityDescription(
@@ -80,27 +80,30 @@ async def async_setup_entry(
                     device_class=determine_victron_device_class(
                         register_name, registerInfo.unit
                     ),
-                    entity_type=registerInfo.entityType
-                    if isinstance(registerInfo.entityType, TextReadEntityType)
+                    entity_type=registerInfo.entity_type
+                    if isinstance(registerInfo.entity_type, TextReadEntityType)
                     else None,
                 )
                 _LOGGER.debug("composed description == %s", description)
 
                 descriptions.append(description)
 
-    entities = []
-    entity = {}
-    for description in descriptions:
-        entity = description
-        entities.append(VictronSensor(victron_coordinator, entity))
+    entities = [
+        VictronSensor(victron_coordinator, description) for description in descriptions
+    ]
 
     # Add an entity for each sensor type
     async_add_entities(entities, True)
 
 
-def determine_victron_device_class(name, unit):
-    """Determine the device class of a sensor based on its name and unit."""
-    if unit == PERCENTAGE and "soc" in name:
+def determine_victron_device_class(name: str | None, unit: str | None) -> Any:
+    """Determine the device class of a sensor based on its name and unit.
+
+    :param name:
+    :param unit:
+    :return:
+    """
+    if name and unit == PERCENTAGE and "soc" in name:
         return SensorDeviceClass.BATTERY
     if unit == PERCENTAGE:
         return None  # Device classes aren't supported for voltage deviation and other % based entities that do not report SOC, moisture or humidity
@@ -120,7 +123,7 @@ def determine_victron_device_class(name, unit):
             SensorDeviceClass.VOLUME_STORAGE
         )  # Perhaps change this to water if only water is measured in volume units
     if unit in [member.value for member in UnitOfSpeed]:
-        if "meteo" in name:
+        if name and "meteo" in name:
             return SensorDeviceClass.WIND_SPEED
         return SensorDeviceClass.SPEED
     if unit in [member.value for member in UnitOfPressure]:
@@ -132,19 +135,22 @@ def determine_victron_device_class(name, unit):
     return None
 
 
-@dataclass
-class VictronEntityDescription(SensorEntityDescription, VictronBaseEntityDescription):
+@dataclass_transform(frozen_default=True)
+class VictronEntityDescription(
+    SensorEntityDescription,  # type: ignore[misc]
+    VictronBaseEntityDescription,
+):
     """Describes victron sensor entity."""
 
-    entity_type: ReadEntityType = None
+    entity_type: ReadEntityType | None = None
 
 
-class VictronSensor(CoordinatorEntity, SensorEntity):
+class VictronSensor(CoordinatorEntity, SensorEntity):  # type: ignore[misc]
     """Representation of a Victron energy sensor."""
 
     def __init__(
         self,
-        coordinator: victronEnergyDeviceUpdateCoordinator,
+        coordinator: VictronEnergyDeviceUpdateCoordinator,
         description: VictronEntityDescription,
     ) -> None:
         """Initialize the sensor."""
@@ -168,12 +174,12 @@ class VictronSensor(CoordinatorEntity, SensorEntity):
 
         super().__init__(coordinator)
 
-    @callback
+    @callback  # type: ignore[misc]
     def _handle_coordinator_update(self) -> None:
         """Get the latest data and updates the states."""
         try:
             if self.available:
-                data = self.description.value_fn(
+                data = self.description.value_fn(  # type: ignore[call-arg]
                     self.coordinator.processed_data(),
                     self.description.slave,
                     self.description.key,
@@ -181,8 +187,11 @@ class VictronSensor(CoordinatorEntity, SensorEntity):
                 if self.entity_type is not None and isinstance(
                     self.entity_type, TextReadEntityType
                 ):
-                    if data in {item.value for item in self.entity_type.decodeEnum}:
-                        self._attr_native_value = self.entity_type.decodeEnum(
+                    if data in {
+                        item.value  # type: ignore[union-attr]
+                        for item in self.entity_type.entity_type_name
+                    }:
+                        self._attr_native_value = self.entity_type.entity_type_name(  # type: ignore[operator]
                             data
                         ).name.split("_DUPLICATE")[0]
                     else:
@@ -191,7 +200,7 @@ class VictronSensor(CoordinatorEntity, SensorEntity):
                             "The reported value %s for entity %s isn't a decobale value. Please report this error to the integrations maintainer",
                             data,
                             self._attr_name,
-                            exc_info=1,
+                            exc_info=1,  # type: ignore[arg-type]
                         )
                 else:
                     self._attr_native_value = data
@@ -203,7 +212,7 @@ class VictronSensor(CoordinatorEntity, SensorEntity):
             self._attr_native_value = None
 
     @property
-    def available(self) -> bool:
+    def available(self) -> Any:
         """Return True if entity is available."""
         full_key = str(self.description.slave) + "." + self.description.key
         return self.coordinator.processed_data()["availability"][full_key]
@@ -212,8 +221,8 @@ class VictronSensor(CoordinatorEntity, SensorEntity):
     def device_info(self) -> entity.DeviceInfo:
         """Return the device info."""
         return entity.DeviceInfo(
-            identifiers={(DOMAIN, self.unique_id.split("_")[0])},
+            identifiers={(DOMAIN, self.unique_id.split("_", maxsplit=1)[0])},
             name=self.unique_id.split("_")[1],
-            model=self.unique_id.split("_")[0],
+            model=self.unique_id.split("_", maxsplit=1)[0],
             manufacturer="victron",  # to be dynamically set for gavazzi and redflow
         )


### PR DESCRIPTION
That was not easy... So no more errors with ruff check, ruff format, mypy. But there are the TODOs with pylint and two other problems.
Unfortunately, I didn't get it work in HA. Pfff... Anyway, the code is there and since it's not urgent, we'll have to understand what's wrong... So many changes...
(I rebased onto #281.)

Errors in the logs:

```text
2025-02-06 11:32:08.536 WARNING (MainThread) [pymodbus.logging] BinaryPayloadDecoder is deprecated and will be removed in v3.9.0 !
Please use "client.convert_from_registers()" or "client.convert_to_registers"
See documentation: "https://pymodbus.readthedocs.io/en/latest/source/client.html#pymodbus.client.mixin.ModbusClientMixin.convert_from_registers"
2025-02-06 11:32:08.547 WARNING (MainThread) [pymodbus.logging] BinaryPayloadDecoder is deprecated and will be removed in v3.9.0 !
Please use "client.convert_from_registers()" or "client.convert_to_registers"
See documentation: "https://pymodbus.readthedocs.io/en/latest/source/client.html#pymodbus.client.mixin.ModbusClientMixin.convert_from_registers"
2025-02-06 11:32:08.552 WARNING (MainThread) [pymodbus.logging] BinaryPayloadDecoder is deprecated and will be removed in v3.9.0 !
Please use "client.convert_from_registers()" or "client.convert_to_registers"
See documentation: "https://pymodbus.readthedocs.io/en/latest/source/client.html#pymodbus.client.mixin.ModbusClientMixin.convert_from_registers"
2025-02-06 11:32:08.552 ERROR (MainThread) [custom_components.victron.coordinator] Unexpected error fetching victron data
Traceback (most recent call last):
  File "/Users/julienpichavant/homeassistant/lib/python3.13/site-packages/homeassistant/helpers/update_coordinator.py", line 380, in _async_refresh
    self.data = await self._async_update_data()
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/julienpichavant/.homeassistant/custom_components/victron/coordinator.py", line 104, in _async_update_data
    self.parse_register_data(
    ~~~~~~~~~~~~~~~~~~~~~~~~^
        data, register_info_dict[name], unit
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ).items()
    ^
  File "/Users/julienpichavant/.homeassistant/custom_components/victron/coordinator.py", line 155, in parse_register_data
    raise DecodedataTypeUnsupported(
        f"Not supported data_type: {value.data_type}"
    )
custom_components.victron.coordinator.DecodedataTypeUnsupported: Not supported data_type: <custom_components.victron.const.STRING object at 0x11f0c4750>
```