### PR TITLE
Make integration compatible with pymodbus 3.11.0 for Hass 2025.9

### DIFF
--- a/custom_components/victron/hub.py
+++ b/custom_components/victron/hub.py
@@ -79,14 +79,14 @@ class VictronHub:
 
     def write_register(self, unit, address, value):
         """Write a register."""
-        slave = int(unit) if unit else 1
-        return self._client.write_register(address=address, value=value, device_id=slave)
+        device_id = int(unit) if unit else 1
+        return self._client.write_register(address=address, value=value, device_id=device_id)
 
     def read_holding_registers(self, unit, address, count):
         """Read holding registers."""
-        slave = int(unit) if unit else 1
+        device_id = int(unit) if unit else 1
         return self._client.read_holding_registers(
-            address=address, count=count, device_id=slave
+            address=address, count=count, device_id=device_id
         )
 
     def calculate_register_count(self, registerInfoDict: OrderedDict):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use "device_id" instead of "slave" in modbus integration
https://github.com/home-assistant/core/pull/150200

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] The code has been formatted using Ruff (`ruff format custom_components/victron`)
