### PR TITLE
Updated handling to resolve TextReadEntityType passed as unit_of_measurement causing recorder statistics failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,13 @@ The voltage profile to use in order to calculate the voltage boundaries (i.e. 4s
 The AC voltage for a single phase in your region (currently supported is US: 120v and EU: 230v)
 This setting is used in combination with AC current to automatically calculate the max wattage for applicable wattage settings.
 
+### Adanced Modbus TCP Settings
+#### TCP Keep Alive (Default: OFF)
+Keepalive attempts to maintain a constant Modbus connection between Cerbo and HomeAssistant.  This is experimental.
+
+#### Modbus TCP Retries (Default: 1)
+When a connection fails, this is the amount of times the plugin will attempt to reconnect before failing and marking entity as unavailable.  Warning: Do not set this too high, as it will deplay marking the entity as unavailable or just hide another connectivity issue.
+
 # Resources
 The following links can be helpful resources:
 - [setting up modbusTCP on the gx device](https://www.victronenergy.com/live/ccgx:modbustcp_faq)

--- a/custom_components/victron/__init__.py
+++ b/custom_components/victron/__init__.py
@@ -6,7 +6,16 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
-from .const import CONF_HOST, CONF_INTERVAL, CONF_PORT, DOMAIN, SCAN_REGISTERS
+from .const import (
+    CONF_HOST,
+    CONF_INTERVAL,
+    CONF_MODBUS_RETRIES,
+    CONF_PORT,
+    CONF_TCP_KEEPALIVE,
+    DEFAULT_MODBUS_RETRIES,
+    DOMAIN,
+    SCAN_REGISTERS,
+)
 from .coordinator import victronEnergyDeviceUpdateCoordinator as Coordinator
 
 PLATFORMS: list[Platform] = [
@@ -34,6 +43,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         config_entry.options[CONF_PORT],
         config_entry.data[SCAN_REGISTERS],
         config_entry.options[CONF_INTERVAL],
+        tcp_keepalive=bool(config_entry.options.get(CONF_TCP_KEEPALIVE, False)),
+        modbus_retries=int(
+            config_entry.options.get(CONF_MODBUS_RETRIES, DEFAULT_MODBUS_RETRIES)
+        ),
     )
     # try:
     #     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/victron/config_flow.py
+++ b/custom_components/victron/config_flow.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.data_entry_flow import FlowResult, section
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.selector import (
     SelectOptionDict,
@@ -27,13 +27,17 @@ from .const import (
     CONF_DC_SYSTEM_VOLTAGE,
     CONF_HOST,
     CONF_INTERVAL,
+    CONF_MODBUS_RETRIES,
     CONF_NUMBER_OF_PHASES,
     CONF_PORT,
+    CONF_TCP_KEEPALIVE,
     CONF_USE_SLIDERS,
     DC_VOLTAGES,
+    DEFAULT_MODBUS_RETRIES,
     DOMAIN,
     PHASE_CONFIGURATIONS,
     SCAN_REGISTERS,
+    SECTION_MODBUS_TCP,
     RegisterInfo,
 )
 from .hub import VictronHub
@@ -42,12 +46,28 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_RESCAN = "rescan"
 
+
+def _flatten_modbus_tcp_section(user_input: dict[str, Any]) -> None:
+    """Promote Modbus TCP section fields to top-level keys used in config entry options."""
+    if SECTION_MODBUS_TCP not in user_input:
+        return
+    nested = user_input.pop(SECTION_MODBUS_TCP)
+    user_input[CONF_TCP_KEEPALIVE] = nested.get(CONF_TCP_KEEPALIVE, False)
+    user_input[CONF_MODBUS_RETRIES] = max(
+        0,
+        min(10, int(nested.get(CONF_MODBUS_RETRIES, DEFAULT_MODBUS_RETRIES))),
+    )
+
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_HOST): str,
         vol.Required(CONF_PORT, default=502): int,
         vol.Required(CONF_INTERVAL, default=30): int,
         vol.Optional(CONF_ADVANCED_OPTIONS, default=False): bool,
+        vol.Optional(CONF_TCP_KEEPALIVE, default=False): bool,
+        vol.Optional(CONF_MODBUS_RETRIES, default=DEFAULT_MODBUS_RETRIES): vol.All(
+            vol.Coerce(int), vol.Range(min=0, max=10)
+        ),
     }
 )
 
@@ -119,12 +139,19 @@ class VictronFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self.port = user_input[CONF_PORT]
             self.interval = user_input[CONF_INTERVAL]
             self.advanced_options = user_input[CONF_ADVANCED_OPTIONS]
+            self.tcp_keepalive = user_input.get(CONF_TCP_KEEPALIVE, False)
+            self.modbus_retries = user_input.get(
+                CONF_MODBUS_RETRIES, DEFAULT_MODBUS_RETRIES
+            )
             return await self.async_step_advanced()
 
         errors = {}
         already_configured = False
 
         user_input[CONF_INTERVAL] = max(user_input[CONF_INTERVAL], 1)
+        user_input[CONF_MODBUS_RETRIES] = max(
+            0, min(10, int(user_input.get(CONF_MODBUS_RETRIES, DEFAULT_MODBUS_RETRIES)))
+        )
 
         try:
             # not yet working
@@ -175,6 +202,10 @@ class VictronFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 )
                 options[CONF_DC_SYSTEM_VOLTAGE] = int(
                     user_input[CONF_DC_SYSTEM_VOLTAGE]
+                )
+                options[CONF_TCP_KEEPALIVE] = getattr(self, "tcp_keepalive", False)
+                options[CONF_MODBUS_RETRIES] = getattr(
+                    self, "modbus_retries", DEFAULT_MODBUS_RETRIES
                 )
 
                 try:
@@ -313,6 +344,8 @@ class VictronOptionFlowHandler(config_entries.OptionsFlow):
     async def async_step_init_read(self, user_input=None):
         """Handle write support and limit settings if requested."""
         config = dict(self.config_entry.options)
+        if user_input is not None:
+            _flatten_modbus_tcp_section(user_input)
         # combine dictionaries with priority given to user_input
         if user_input[CONF_RESCAN]:
             info = await validate_input(self.hass, config)
@@ -337,6 +370,8 @@ class VictronOptionFlowHandler(config_entries.OptionsFlow):
     async def async_step_init_write(self, user_input=None):
         """Handle write support and limit settings if requested."""
         config = dict(self.config_entry.options)
+        if user_input is not None:
+            _flatten_modbus_tcp_section(user_input)
         # remove temp options =
         if user_input[CONF_RESCAN]:
             info = await validate_input(self.hass, config)
@@ -369,8 +404,19 @@ class VictronOptionFlowHandler(config_entries.OptionsFlow):
         config = dict(self.config_entry.options)
 
         if user_input is not None:
+            _flatten_modbus_tcp_section(user_input)
             if user_input[CONF_INTERVAL] not in (None, ""):
-                config[CONF_INTERVAL] = user_input[CONF_INTERVAL]
+                config[CONF_INTERVAL] = max(int(user_input[CONF_INTERVAL]), 1)
+            config[CONF_TCP_KEEPALIVE] = user_input.get(CONF_TCP_KEEPALIVE, False)
+            config[CONF_MODBUS_RETRIES] = max(
+                0,
+                min(
+                    10,
+                    int(
+                        user_input.get(CONF_MODBUS_RETRIES, DEFAULT_MODBUS_RETRIES)
+                    ),
+                ),
+            )
 
             try:
                 if user_input[CONF_RESCAN]:
@@ -403,16 +449,34 @@ class VictronOptionFlowHandler(config_entries.OptionsFlow):
 
     def init_read_form(self, errors: dict):
         """Handle read support and limit settings if requested."""
+        opts = self.config_entry.options
         return self.async_show_form(
             step_id="init_read",
             errors=errors,
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        CONF_INTERVAL, default=self.config_entry.options[CONF_INTERVAL]
+                        CONF_INTERVAL, default=opts[CONF_INTERVAL]
                     ): vol.All(vol.Coerce(int)),
                     vol.Optional(CONF_RESCAN, default=False): bool,
                     vol.Optional(CONF_ADVANCED_OPTIONS, default=False): bool,
+                    vol.Required(SECTION_MODBUS_TCP): section(
+                        vol.Schema(
+                            {
+                                vol.Optional(
+                                    CONF_TCP_KEEPALIVE,
+                                    default=opts.get(CONF_TCP_KEEPALIVE, False),
+                                ): bool,
+                                vol.Required(
+                                    CONF_MODBUS_RETRIES,
+                                    default=opts.get(
+                                        CONF_MODBUS_RETRIES, DEFAULT_MODBUS_RETRIES
+                                    ),
+                                ): vol.All(vol.Coerce(int), vol.Range(min=0, max=10)),
+                            }
+                        ),
+                        {"collapsed": False},
+                    ),
                 },
             ),
         )
@@ -494,6 +558,23 @@ class VictronOptionFlowHandler(config_entries.OptionsFlow):
                     ): bool,
                     vol.Optional(CONF_RESCAN, default=False): bool,
                     vol.Optional(CONF_ADVANCED_OPTIONS, default=True): bool,
+                    vol.Required(SECTION_MODBUS_TCP): section(
+                        vol.Schema(
+                            {
+                                vol.Optional(
+                                    CONF_TCP_KEEPALIVE,
+                                    default=config.get(CONF_TCP_KEEPALIVE, False),
+                                ): bool,
+                                vol.Required(
+                                    CONF_MODBUS_RETRIES,
+                                    default=config.get(
+                                        CONF_MODBUS_RETRIES, DEFAULT_MODBUS_RETRIES
+                                    ),
+                                ): vol.All(vol.Coerce(int), vol.Range(min=0, max=10)),
+                            }
+                        ),
+                        {"collapsed": False},
+                    ),
                 },
             ),
         )

--- a/custom_components/victron/const.py
+++ b/custom_components/victron/const.py
@@ -47,6 +47,12 @@ CONF_DC_SYSTEM_VOLTAGE = "dc_voltage"
 CONF_AC_SYSTEM_VOLTAGE = "ac_voltage"
 CONF_NUMBER_OF_PHASES = "number_of_phases"
 CONF_USE_SLIDERS = "use_sliders"
+CONF_TCP_KEEPALIVE = "tcp_keepalive"
+CONF_MODBUS_RETRIES = "modbus_retries"
+# Options flow section key (matches translations options.step.*.sections.modbus_tcp)
+SECTION_MODBUS_TCP = "modbus_tcp"
+
+DEFAULT_MODBUS_RETRIES = 1
 
 AC_VOLTAGES = {
     "US (120)": 120,

--- a/custom_components/victron/const.py
+++ b/custom_components/victron/const.py
@@ -731,7 +731,7 @@ vebus_registers_4 = {
         230, UINT16, 1, entityType=ButtonWriteType()
     ),
     "vebus_microgrid_error": RegisterInfo(
-        231, UINT16, TextReadEntityType(microgrid_error)
+        231, UINT16, entityType=TextReadEntityType(microgrid_error)
     ),
 }
 

--- a/custom_components/victron/coordinator.py
+++ b/custom_components/victron/coordinator.py
@@ -18,6 +18,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
+    DEFAULT_MODBUS_RETRIES,
     DOMAIN,
     INT16,
     INT32,
@@ -46,13 +47,21 @@ class victronEnergyDeviceUpdateCoordinator(DataUpdateCoordinator):
         port: str,
         decodeInfo: OrderedDict,
         interval: int,
+        *,
+        tcp_keepalive: bool = False,
+        modbus_retries: int = DEFAULT_MODBUS_RETRIES,
     ) -> None:
         """Initialize Update Coordinator."""
 
         super().__init__(
             hass, _LOGGER, name=DOMAIN, update_interval=timedelta(seconds=interval)
         )
-        self.api = VictronHub(host, port)
+        self.api = VictronHub(
+            host,
+            port,
+            tcp_keepalive=tcp_keepalive,
+            modbus_retries=modbus_retries,
+        )
         self.api.connect()
         self.decodeInfo = decodeInfo
         self.interval = interval
@@ -184,7 +193,7 @@ class victronEnergyDeviceUpdateCoordinator(DataUpdateCoordinator):
                 self.api_update, unit, registerData
             )
 
-        except HomeAssistantError as e:
+        except (HomeAssistantError, OSError) as e:
             raise UpdateFailed("Fetching registers failed") from e
 
     def write_register(self, unit, address, value):
@@ -199,12 +208,10 @@ class victronEnergyDeviceUpdateCoordinator(DataUpdateCoordinator):
 
     def api_write(self, unit, address, value):
         """Write to the api."""
-        # recycle connection
         return self.api.write_register(unit=unit, address=address, value=value)
 
     def api_update(self, unit, registerInfo):
         """Update the api."""
-        # recycle connection
         return self.api.read_holding_registers(
             unit=unit,
             address=self.api.get_first_register_id(registerInfo),

--- a/custom_components/victron/hub.py
+++ b/custom_components/victron/hub.py
@@ -1,7 +1,9 @@
 """Support for Victron Energy devices."""
 
 from collections import OrderedDict
+import errno
 import logging
+import socket
 import threading
 
 from packaging import version
@@ -11,6 +13,7 @@ from pymodbus.client import ModbusTcpClient
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import (
+    DEFAULT_MODBUS_RETRIES,
     INT16,
     INT32,
     INT64,
@@ -24,14 +27,47 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# TCP / transport failures where closing the socket and connecting again is appropriate.
+_RECOVERABLE_ERRNOS = frozenset(
+    {
+        errno.EPIPE,
+        errno.ECONNRESET,
+        errno.ECONNABORTED,
+        errno.ENOTCONN,
+        errno.ETIMEDOUT,
+        errno.EHOSTUNREACH,
+        errno.ENETUNREACH,
+    }
+)
+
+
+def _is_recoverable_transport_error(exc: Exception) -> bool:
+    """Return True if the exception may be resolved by reconnecting the Modbus client."""
+    if isinstance(exc, TimeoutError):
+        return True
+    if isinstance(exc, (BrokenPipeError, ConnectionResetError)):
+        return True
+    if isinstance(exc, OSError):
+        return exc.errno in _RECOVERABLE_ERRNOS
+    return False
+
 
 class VictronHub:
     """Victron Hub."""
 
-    def __init__(self, host: str, port: int) -> None:
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        *,
+        tcp_keepalive: bool = False,
+        modbus_retries: int = DEFAULT_MODBUS_RETRIES,
+    ) -> None:
         """Initialize."""
         self.host = host
         self.port = port
+        self._keepalive = tcp_keepalive
+        self._modbus_retries = max(0, int(modbus_retries))
         self._client = ModbusTcpClient(host=self.host, port=self.port)
         self._lock = threading.Lock()
 
@@ -73,30 +109,104 @@ class VictronHub:
             )
         return raw
 
+    def _apply_tcp_keepalive(self) -> None:
+        """Enable SO_KEEPALIVE on the underlying TCP socket. Caller must hold _lock."""
+        if not self._keepalive:
+            return
+        sock = getattr(self._client, "socket", None)
+        if sock is None:
+            return
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        except OSError as err:
+            _LOGGER.warning("Could not enable TCP keepalive: %s", err)
+
     def connect(self):
         """Connect to the Modbus TCP server."""
-        return self._client.connect()
+        with self._lock:
+            ok = self._client.connect()
+            if ok:
+                self._apply_tcp_keepalive()
+            return ok
 
     def disconnect(self):
         """Disconnect from the Modbus TCP server."""
-        if self._client.is_socket_open():
-            return self._client.close()
+        with self._lock:
+            if self._client.is_socket_open():
+                return self._client.close()
         return None
+
+    def _reconnect(self) -> None:
+        """Close the socket and open a new Modbus TCP session. Caller must hold _lock."""
+        try:
+            self._client.close()
+        except OSError:
+            pass
+        if not self._client.connect():
+            raise ConnectionError(
+                f"Could not reconnect to Modbus TCP at {self.host}:{self.port}"
+            )
+        self._apply_tcp_keepalive()
+
+    def _ensure_connected(self) -> None:
+        """Connect if the client has no open socket. Caller must hold _lock."""
+        if not self._client.is_socket_open():
+            if not self._client.connect():
+                raise ConnectionError(
+                    f"Could not connect to Modbus TCP at {self.host}:{self.port}"
+                )
+            self._apply_tcp_keepalive()
+
+    def _transport_attempts(self) -> int:
+        """Number of Modbus operations to attempt (first try + retries)."""
+        return self._modbus_retries + 1
 
     def write_register(self, unit, address, value):
         """Write a register."""
         slave = int(unit) if unit else 1
-        return self._client.write_register(
-            address=address, value=value, device_id=slave
-        )
+        max_attempts = self._transport_attempts()
+        with self._lock:
+            for attempt in range(max_attempts):
+                try:
+                    self._ensure_connected()
+                    return self._client.write_register(
+                        address=address, value=value, device_id=slave
+                    )
+                except Exception as err:
+                    if (
+                        attempt < max_attempts - 1
+                        and _is_recoverable_transport_error(err)
+                    ):
+                        _LOGGER.warning(
+                            "Modbus write failed (%s), reconnecting", err
+                        )
+                        self._reconnect()
+                        continue
+                    raise
 
     def read_holding_registers(self, unit, address, count):
         """Read holding registers."""
         slave = int(unit) if unit else 1
-        _LOGGER.info("Reading unit %s address %s count %s", unit, address, count)
-        return self._client.read_holding_registers(
-            address=address, count=count, device_id=slave
-        )
+        max_attempts = self._transport_attempts()
+        _LOGGER.debug("Reading unit %s address %s count %s", unit, address, count)
+        with self._lock:
+            for attempt in range(max_attempts):
+                try:
+                    self._ensure_connected()
+                    return self._client.read_holding_registers(
+                        address=address, count=count, device_id=slave
+                    )
+                except Exception as err:
+                    if (
+                        attempt < max_attempts - 1
+                        and _is_recoverable_transport_error(err)
+                    ):
+                        _LOGGER.warning(
+                            "Modbus read failed (%s), reconnecting", err
+                        )
+                        self._reconnect()
+                        continue
+                    raise
 
     def calculate_register_count(self, registerInfoDict: OrderedDict):
         """Calculate the number of registers to read."""
@@ -146,8 +256,8 @@ class VictronHub:
                         )
                     else:
                         working_registers.append(key)
-                except HomeAssistantError as e:
-                    _LOGGER.error(e)
+                except (HomeAssistantError, OSError) as e:
+                    _LOGGER.error("Device scan read failed: %s", e)
 
             if len(working_registers) > 0:
                 valid_devices[unit] = working_registers

--- a/custom_components/victron/sensor.py
+++ b/custom_components/victron/sensor.py
@@ -74,12 +74,12 @@ async def async_setup_entry(
                 description = VictronEntityDescription(
                     key=register_name,
                     name=register_name.replace("_", " "),
-                    native_unit_of_measurement=registerInfo.unit,
-                    state_class=registerInfo.determine_stateclass(),
+                    native_unit_of_measurement=registerInfo.unit if not isinstance(registerInfo.entityType, TextReadEntityType) else None,
+                    state_class=registerInfo.determine_stateclass() if not isinstance(registerInfo.entityType, TextReadEntityType) else None,
                     slave=slave,
                     device_class=determine_victron_device_class(
                         register_name, registerInfo.unit
-                    ),
+                    ) if not isinstance(registerInfo.entityType, TextReadEntityType) else None,
                     entity_type=registerInfo.entityType
                     if isinstance(registerInfo.entityType, TextReadEntityType)
                     else None,

--- a/custom_components/victron/strings.json
+++ b/custom_components/victron/strings.json
@@ -6,7 +6,9 @@
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]",
           "interval": "[%key:common::config_flow::data::interval%]",
-          "advanced": "%key:common::config_flow::data::advanced%"
+          "advanced": "%key:common::config_flow::data::advanced%",
+          "tcp_keepalive": "Enable TCP keepalive (default: off)",
+          "modbus_retries": "Modbus retries after transport error (default: 1)"
         }
       },
       "advanced": {
@@ -28,5 +30,47 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
-  }    
+  },
+  "options": {
+    "step": {
+      "init_read": {
+        "data": {
+          "rescan": "Rescan available devices",
+          "interval": "[%key:common::config_flow::data::interval%]",
+          "advanced": "Enable write support"
+        },
+        "sections": {
+          "modbus_tcp": {
+            "name": "Advanced: Modbus TCP Settings",
+            "data": {
+              "tcp_keepalive": "Enable TCP keepalive (default: off)",
+              "modbus_retries": "Modbus retries after transport error (default: 1)"
+            }
+          }
+        }
+      },
+      "init_write": {
+        "data": {
+          "rescan": "Rescan available devices",
+          "interval": "[%key:common::config_flow::data::interval%]",
+          "ac_voltage": "[%key:common::config_flow::data::ac_voltage%]",
+          "ac_current": "[%key:common::config_flow::data::ac_current%]",
+          "dc_voltage": "[%key:common::config_flow::data::dc_voltage%]",
+          "dc_current": "[%key:common::config_flow::data::dc_current%]",
+          "number_of_phases": "[%key:common::config_flow::data::number_of_phases%]",
+          "use_sliders": "[%key:common::config_flow::data::use_sliders%]",
+          "advanced": "switch to read only mode if unchecked (when submitted)"
+        },
+        "sections": {
+          "modbus_tcp": {
+            "name": "Advanced: Modbus TCP Settings",
+            "data": {
+              "tcp_keepalive": "Enable TCP keepalive (default: off)",
+              "modbus_retries": "Modbus retries after transport error (default: 1)"
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/custom_components/victron/translations/de.json
+++ b/custom_components/victron/translations/de.json
@@ -15,7 +15,9 @@
                     "host": "Host",
                     "port": "Port",
                     "interval": "Aktualisierungsintervall in (s)",
-                    "advanced": "Aktiviert Schreibunterstützung und ermöglicht das Setzen von Schreibgrenzen"
+                    "advanced": "Aktiviert Schreibunterstützung und ermöglicht das Setzen von Schreibgrenzen",
+                    "tcp_keepalive": "TCP-Keepalive aktivieren (Standard: aus)",
+                    "modbus_retries": "Modbus-Wiederholungen nach Transportfehler (Standard: 1)"
                 }
             },
             "advanced": {
@@ -49,6 +51,15 @@
                     "number_of_phases": "Die Phasenkonfiguration Ihres Systems",
                     "use_sliders": "Verwendet abgestufte Schieberegler für beschreibbare Zahlenwerte",
                     "advanced": "Wechselt in den Nur-Lesen-Modus, wenn nicht markiert (beim Absenden)"
+                },
+                "sections": {
+                    "modbus_tcp": {
+                        "name": "Erweitert: Modbus-TCP-Einstellungen",
+                        "data": {
+                            "tcp_keepalive": "TCP-Keepalive aktivieren (Standard: aus)",
+                            "modbus_retries": "Modbus-Wiederholungen nach Transportfehler (Standard: 1)"
+                        }
+                    }
                 }
             },
             "init_read": {
@@ -56,6 +67,15 @@
                     "rescan": "Verfügbare Geräte erneut scannen. Dadurch werden alle verfügbaren Geräte erneut gescannt",
                     "interval": "Aktualisierungsintervall in (s)",
                     "advanced": "Schreibunterstützung aktivieren"
+                },
+                "sections": {
+                    "modbus_tcp": {
+                        "name": "Erweitert: Modbus-TCP-Einstellungen",
+                        "data": {
+                            "tcp_keepalive": "TCP-Keepalive aktivieren (Standard: aus)",
+                            "modbus_retries": "Modbus-Wiederholungen nach Transportfehler (Standard: 1)"
+                        }
+                    }
                 }
             },
             "advanced": {

--- a/custom_components/victron/translations/en.json
+++ b/custom_components/victron/translations/en.json
@@ -15,7 +15,9 @@
                     "host": "Host",
                     "port": "Port",
                     "interval": "update interval in (s)",
-                    "advanced": "Enables write support and allows setting write limits"
+                    "advanced": "Enables write support and allows setting write limits",
+                    "tcp_keepalive": "Enable TCP keepalive (default: off)",
+                    "modbus_retries": "Modbus retries after transport error (default: 1)"
                 }
             },
             "advanced": {
@@ -49,6 +51,15 @@
                     "number_of_phases": "The phase configuration of your system",
                     "use_sliders": "Use stepped sliders for writeable number entities",
                     "advanced": "switch to read only mode if unchecked (when submitted)"
+                },
+                "sections": {
+                    "modbus_tcp": {
+                        "name": "Advanced: Modbus TCP Settings",
+                        "data": {
+                            "tcp_keepalive": "Enable TCP keepalive (default: off)",
+                            "modbus_retries": "Modbus retries after transport error (default: 1)"
+                        }
+                    }
                 }
             },
             "init_read": {
@@ -56,6 +67,15 @@
                     "rescan": "Rescan available devices. This will rescan all available devices",
                     "interval": "Update interval in (s)",
                     "advanced": "Enable write support"
+                },
+                "sections": {
+                    "modbus_tcp": {
+                        "name": "Advanced: Modbus TCP Settings",
+                        "data": {
+                            "tcp_keepalive": "Enable TCP keepalive (default: off)",
+                            "modbus_retries": "Modbus retries after transport error (default: 1)"
+                        }
+                    }
                 }
             },
             "advanced": {

--- a/custom_components/victron/translations/es.json
+++ b/custom_components/victron/translations/es.json
@@ -15,7 +15,9 @@
                     "host": "Host",
                     "port": "Puerto",
                     "interval": "Intervalo de actualización en (s)",
-                    "advanced": "Habilita el soporte de escritura y permite establecer límites de escritura"
+                    "advanced": "Habilita el soporte de escritura y permite establecer límites de escritura",
+                    "tcp_keepalive": "Activar TCP keepalive (predeterminado: desactivado)",
+                    "modbus_retries": "Reintentos Modbus tras error de transporte (predeterminado: 1)"
                 }
             },
             "advanced": {
@@ -49,6 +51,15 @@
                     "number_of_phases": "La configuración de fases de tu sistema",
                     "use_sliders": "Usar controles deslizantes escalonados para entidades numéricas editables",
                     "advanced": "Cambiar al modo solo lectura si no está seleccionado (al enviar)"
+                },
+                "sections": {
+                    "modbus_tcp": {
+                        "name": "Avanzado: ajustes Modbus TCP",
+                        "data": {
+                            "tcp_keepalive": "Activar TCP keepalive (predeterminado: desactivado)",
+                            "modbus_retries": "Reintentos Modbus tras error de transporte (predeterminado: 1)"
+                        }
+                    }
                 }
             },
             "init_read": {
@@ -56,6 +67,15 @@
                     "rescan": "Reescanear dispositivos disponibles. Esto reescaneará todos los dispositivos disponibles",
                     "interval": "Intervalo de actualización en (s)",
                     "advanced": "Habilitar soporte de escritura"
+                },
+                "sections": {
+                    "modbus_tcp": {
+                        "name": "Avanzado: ajustes Modbus TCP",
+                        "data": {
+                            "tcp_keepalive": "Activar TCP keepalive (predeterminado: desactivado)",
+                            "modbus_retries": "Reintentos Modbus tras error de transporte (predeterminado: 1)"
+                        }
+                    }
                 }
             },
             "advanced": {

--- a/custom_components/victron/translations/fr.json
+++ b/custom_components/victron/translations/fr.json
@@ -15,7 +15,9 @@
                     "host": "Hôte",
                     "port": "Port",
                     "interval": "Intervalle de mise à jour en (s)",
-                    "advanced": "Active le support en écriture et permet de définir des limites d'écriture"
+                    "advanced": "Active le support en écriture et permet de définir des limites d'écriture",
+                    "tcp_keepalive": "Activer le TCP keepalive (défaut : désactivé)",
+                    "modbus_retries": "Nouvelles tentatives Modbus après erreur de transport (défaut : 1)"
                 }
             },
             "advanced": {
@@ -49,6 +51,15 @@
                     "number_of_phases": "La configuration de phase de votre système",
                     "use_sliders": "Utilise des curseurs gradués pour les entités numériques modifiables",
                     "advanced": "Basculer en mode lecture seule si décoché (lors de l'envoi)"
+                },
+                "sections": {
+                    "modbus_tcp": {
+                        "name": "Avancé : paramètres Modbus TCP",
+                        "data": {
+                            "tcp_keepalive": "Activer le TCP keepalive (défaut : désactivé)",
+                            "modbus_retries": "Nouvelles tentatives Modbus après erreur de transport (défaut : 1)"
+                        }
+                    }
                 }
             },
             "init_read": {
@@ -56,6 +67,15 @@
                     "rescan": "Rescanner les appareils disponibles. Cela rescannera tous les appareils disponibles",
                     "interval": "Intervalle de mise à jour en (s)",
                     "advanced": "Activer le support en écriture"
+                },
+                "sections": {
+                    "modbus_tcp": {
+                        "name": "Avancé : paramètres Modbus TCP",
+                        "data": {
+                            "tcp_keepalive": "Activer le TCP keepalive (défaut : désactivé)",
+                            "modbus_retries": "Nouvelles tentatives Modbus après erreur de transport (défaut : 1)"
+                        }
+                    }
                 }
             },
             "advanced": {

--- a/custom_components/victron/translations/it.json
+++ b/custom_components/victron/translations/it.json
@@ -15,7 +15,9 @@
                     "host": "Host",
                     "port": "Porta",
                     "interval": "Intervallo di aggiornamento in (s)",
-                    "advanced": "Abilita il supporto in scrittura e consente di impostare limiti di scrittura"
+                    "advanced": "Abilita il supporto in scrittura e consente di impostare limiti di scrittura",
+                    "tcp_keepalive": "Abilita keepalive TCP (predefinito: disattivato)",
+                    "modbus_retries": "Tentativi Modbus dopo errore di trasporto (predefinito: 1)"
                 }
             },
             "advanced": {
@@ -49,6 +51,15 @@
                     "number_of_phases": "La configurazione delle fasi del tuo sistema",
                     "use_sliders": "Utilizza cursori a passi per entità numeriche scrivibili",
                     "advanced": "Passa alla modalità sola lettura se deselezionato (al momento dell'invio)"
+                },
+                "sections": {
+                    "modbus_tcp": {
+                        "name": "Avanzate: impostazioni Modbus TCP",
+                        "data": {
+                            "tcp_keepalive": "Abilita keepalive TCP (predefinito: disattivato)",
+                            "modbus_retries": "Tentativi Modbus dopo errore di trasporto (predefinito: 1)"
+                        }
+                    }
                 }
             },
             "init_read": {
@@ -56,6 +67,15 @@
                     "rescan": "Esegui nuovamente la scansione dei dispositivi disponibili. Questo eseguirà la scansione di tutti i dispositivi disponibili",
                     "interval": "Intervallo di aggiornamento in (s)",
                     "advanced": "Abilita il supporto in scrittura"
+                },
+                "sections": {
+                    "modbus_tcp": {
+                        "name": "Avanzate: impostazioni Modbus TCP",
+                        "data": {
+                            "tcp_keepalive": "Abilita keepalive TCP (predefinito: disattivato)",
+                            "modbus_retries": "Tentativi Modbus dopo errore di trasporto (predefinito: 1)"
+                        }
+                    }
                 }
             },
             "advanced": {

--- a/custom_components/victron/translations/nl.json
+++ b/custom_components/victron/translations/nl.json
@@ -15,7 +15,9 @@
                     "host": "Host",
                     "port": "Poort",
                     "interval": "Update-interval in (s)",
-                    "advanced": "Schakelt schrijfondersteuning in en maakt het instellen van schrijfbeperkingen mogelijk"
+                    "advanced": "Schakelt schrijfondersteuning in en maakt het instellen van schrijfbeperkingen mogelijk",
+                    "tcp_keepalive": "TCP keepalive inschakelen (standaard: uit)",
+                    "modbus_retries": "Modbus-pogingen na transportfout (standaard: 1)"
                 }
             },
             "advanced": {
@@ -49,6 +51,15 @@
                     "number_of_phases": "De faseconfiguratie van uw systeem",
                     "use_sliders": "Gebruik trapsgewijze schuifregelaars voor beschrijfbare numerieke eenheden",
                     "advanced": "Schakel over naar alleen-lezen modus als uitgeschakeld (bij indienen)"
+                },
+                "sections": {
+                    "modbus_tcp": {
+                        "name": "Geavanceerd: Modbus TCP-instellingen",
+                        "data": {
+                            "tcp_keepalive": "TCP keepalive inschakelen (standaard: uit)",
+                            "modbus_retries": "Modbus-pogingen na transportfout (standaard: 1)"
+                        }
+                    }
                 }
             },
             "init_read": {
@@ -56,6 +67,15 @@
                     "rescan": "Beschikbare apparaten opnieuw scannen. Dit scant alle beschikbare apparaten opnieuw",
                     "interval": "Update-interval in (s)",
                     "advanced": "Schrijfondersteuning inschakelen"
+                },
+                "sections": {
+                    "modbus_tcp": {
+                        "name": "Geavanceerd: Modbus TCP-instellingen",
+                        "data": {
+                            "tcp_keepalive": "TCP keepalive inschakelen (standaard: uit)",
+                            "modbus_retries": "Modbus-pogingen na transportfout (standaard: 1)"
+                        }
+                    }
                 }
             },
             "advanced": {

--- a/custom_components/victron/translations/sv.json
+++ b/custom_components/victron/translations/sv.json
@@ -15,7 +15,9 @@
                     "host": "Värd",
                     "port": "Port",
                     "interval": "Uppdateringsintervall i (s)",
-                    "advanced": "Aktiverar skrivstöd och möjliggör inställning av skrivgränser"
+                    "advanced": "Aktiverar skrivstöd och möjliggör inställning av skrivgränser",
+                    "tcp_keepalive": "Aktivera TCP keepalive (standard: av)",
+                    "modbus_retries": "Modbus-försök efter transportfel (standard: 1)"
                 }
             },
             "advanced": {
@@ -49,6 +51,15 @@
                     "number_of_phases": "Faskonfigurationen i ditt system",
                     "use_sliders": "Använder stegade reglage för skrivbara numeriska värden",
                     "advanced": "Växla till skrivskyddat läge om det inte är markerat (vid insändning)"
+                },
+                "sections": {
+                    "modbus_tcp": {
+                        "name": "Avancerat: Modbus TCP-inställningar",
+                        "data": {
+                            "tcp_keepalive": "Aktivera TCP keepalive (standard: av)",
+                            "modbus_retries": "Modbus-försök efter transportfel (standard: 1)"
+                        }
+                    }
                 }
             },
             "init_read": {
@@ -56,6 +67,15 @@
                     "rescan": "Skanna om tillgängliga enheter. Detta kommer att skanna om alla tillgängliga enheter",
                     "interval": "Uppdateringsintervall i (s)",
                     "advanced": "Aktivera skrivstöd"
+                },
+                "sections": {
+                    "modbus_tcp": {
+                        "name": "Avancerat: Modbus TCP-inställningar",
+                        "data": {
+                            "tcp_keepalive": "Aktivera TCP keepalive (standard: av)",
+                            "modbus_retries": "Modbus-försök efter transportfel (standard: 1)"
+                        }
+                    }
                 }
             },
             "advanced": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
When Home Assistant's recorder attempts to compile statistics for Victron text/enum sensor entities (e.g. sensor.victronvebus_microgrid_error), it crashes with:
sqlalchemy.exc.ProgrammingError: (sqlite3.ProgrammingError) Error binding parameter 3: 
type 'TextReadEntityType' is not supported
[SQL: INSERT INTO statistics_meta (statistic_id, source, unit_of_measurement, ...) VALUES ...]
[parameters: ('sensor.victronvebus_microgrid_error227', 'recorder', 
<custom_components.victron.const.TextReadEntityType object at 0x...>, ...)]
This occurs because registerInfo.unit for TextReadEntityType registers holds a TextReadEntityType object rather than a plain string or None. The HA recorder passes this directly to SQLite as a bind parameter, which SQLite cannot handle, causing the statistics task to fail on every cycle. The result is that all history recording stops for the entire HA instance, not just the affected entity.
Root Cause
In async_setup_entry within sensor.py, the VictronEntityDescription is constructed without guarding against non-string unit values for text entities:
python# Before — passes TextReadEntityType object directly
description = VictronEntityDescription(
    native_unit_of_measurement=registerInfo.unit,      # ← object, not string
    state_class=registerInfo.determine_stateclass(),   # ← meaningless for text entities
    device_class=determine_victron_device_class(...)   # ← unit is not a string here
    ...
)
Fix
Guard all three unit-dependent properties against TextReadEntityType instances, returning None for text entities which have no meaningful numeric unit, state class, or device class:
python# After — safely returns None for text entities
is_text_entity = isinstance(registerInfo.entityType, TextReadEntityType)

description = VictronEntityDescription(
    native_unit_of_measurement=registerInfo.unit if not is_text_entity else None,
    state_class=registerInfo.determine_stateclass() if not is_text_entity else None,
    device_class=determine_victron_device_class(register_name, registerInfo.unit) if not is_text_entity else None,
    ...
)
Impact

Fixes recorder statistics failure for all users with any text/enum Victron entities present
Restores full HA history recording which is blocked by this error
No functional change to how text entity values are decoded or displayed — only the metadata passed to the recorder changes
Affects any unit ID that exposes text registers (e.g. unit 227 microgrid_error, mode registers, alarm state registers)

Testing
Verified by checking HA logs after applying the patch — Unhandled database error while processing StatisticsTask errors no longer appear and history recording resumes for all entities.
HA Version Confirmed Affected

Home Assistant OS 17.1 / Core 2026.2.3

- This PR fixes or closes issue: fixes #418 
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] There is no commented out code in this PR.
- [X] The code has been formatted using Ruff (`ruff format custom_components/victron`)
