### PR TITLE
Fix recorder crash and noisy logs for Victron integration

### DIFF
--- a/custom_components/victron/const.py
+++ b/custom_components/victron/const.py
@@ -725,7 +725,7 @@ vebus_registers_4 = {
         230, UINT16, 1, entityType=ButtonWriteType()
     ),
     "vebus_microgrid_error": RegisterInfo(
-        231, UINT16, TextReadEntityType(microgrid_error)
+        231, UINT16, entityType=TextReadEntityType(microgrid_error)
     ),
 }
 

--- a/custom_components/victron/sensor.py
+++ b/custom_components/victron/sensor.py
@@ -36,6 +36,7 @@ from .const import (
     ReadEntityType,
     TextReadEntityType,
     register_info_dict,
+    UINT16_MAX,
 )
 from .coordinator import victronEnergyDeviceUpdateCoordinator
 
@@ -181,7 +182,9 @@ class VictronSensor(CoordinatorEntity, SensorEntity):
                 if self.entity_type is not None and isinstance(
                     self.entity_type, TextReadEntityType
                 ):
-                    if data in {item.value for item in self.entity_type.decodeEnum}:
+                    if data in (UINT16_MAX, float(UINT16_MAX)):
+                        self._attr_native_value = None
+                    elif data in {item.value for item in self.entity_type.decodeEnum}:
                         self._attr_native_value = self.entity_type.decodeEnum(
                             data
                         ).name.split("_DUPLICATE")[0]


### PR DESCRIPTION
## Summary
                                                                                                                                                                                                                                                          
- Fix TextReadEntityType being passed as positional unit argument instead of entityType keyword argument in vebus_microgrid_error RegisterInfo, which caused sqlite3 binding errors crashing the HA recorder and JSON serialization failures in the
/api/states endpoint                                                                                                                                                                                                                                        
- Handle Modbus UINT16_MAX (65535) sentinel value ("not available") in enum-based sensors, returning None instead of logging errors for non-decodable values