### PR TITLE
Fix: Handle Modbus 0xFFFF (65535) as unavailable instead of logging error…

### DIFF
--- a/custom_components/victron/sensor.py
+++ b/custom_components/victron/sensor.py
@@ -181,7 +181,13 @@ class VictronSensor(CoordinatorEntity, SensorEntity):
                 if self.entity_type is not None and isinstance(
                     self.entity_type, TextReadEntityType
                 ):
-                    if data in {item.value for item in self.entity_type.decodeEnum}:
+                    if data in (65535, 65535.0):
+                        self._attr_native_value = None
+                        _LOGGER.debug(
+                            "Value 0xFFFF received for entity %s, treating as unavailable",
+                            self._attr_name,
+                        )
+                    elif data in {item.value for item in self.entity_type.decodeEnum}:
                         self._attr_native_value = self.entity_type.decodeEnum(
                             data
                         ).name.split("_DUPLICATE")[0]


### PR DESCRIPTION
This errors that are flooding logs on HA occur on v0.6.4, but also on the new beta v0.7-beta5.
The code i changed fixes it on v0.6.4, but i didn't tested it on v0.7 as I don't have it installed.
Thank you for your nice work,

The value 65535 (0xFFFF) is the standard Modbus response for "no data" or "no alarm active" from Victron equipment. Previously, this value was not in the decodeEnum set, causing sensor.py to log it as an error continuously (17,000+ occurrences in ~5 hours in my setup).

This fix adds a check for 65535/65535.0 before attempting enum decoding. When detected, the sensor state is set to None (unavailable in HA) and the event is logged at debug level instead of error.

Affected entities in my setup:
- solarcharger alarm lowvoltage
- solarcharger alarm highvoltage

Tested on:
- Home Assistant 2026.4.2 (HAOS 17.2)
- Victron GX modbus TCP v0.6.4
- Modbus TCP connection (port 502)

Confirmed fix eliminates all error log spam while maintaining correct sensor behavior — sensors show as "unavailable" when no alarm is active, which is the expected state.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format custom_components/victron`)
