### PR TITLE
Skip register blocks with undecodable text values during detection

### DIFF
--- a/custom_components/victron/hub.py
+++ b/custom_components/victron/hub.py
@@ -15,6 +15,7 @@ from .const import (
     INT32,
     INT64,
     STRING,
+    TextReadEntityType,
     UINT16,
     UINT32,
     UINT64,
@@ -144,6 +145,15 @@ class VictronHub:
                             address,
                             count,
                         )
+                    elif self._block_has_undecodable_text(
+                        register_definition, result, address
+                    ):
+                        _LOGGER.debug(
+                            "register set %s on unit %s returned an undecodable "
+                            "text value; treating as not present",
+                            key,
+                            unit,
+                        )
                     else:
                         working_registers.append(key)
                 except HomeAssistantError as e:
@@ -155,3 +165,24 @@ class VictronHub:
                 _LOGGER.debug("no registers found for unit: %s", unit)
 
         return valid_devices
+
+    def _block_has_undecodable_text(
+        self, register_definition: OrderedDict, result, first_address: int
+    ) -> bool:
+        """Return True if any TextReadEntityType register in the block decodes outside its enum.
+
+        Some Victron devices return well-formed Modbus responses with garbage values
+        for registers their hardware does not actually populate (e.g. battery_balancer_status
+        on a BMS without a Battery Balancer). Without this check the block is marked
+        present and the resulting entity logs a decode error every poll cycle.
+        """
+        for info in register_definition.values():
+            if not isinstance(info.entityType, TextReadEntityType):
+                continue
+            offset = info.register - first_address
+            if offset < 0 or offset >= len(result.registers):
+                continue
+            valid_values = {item.value for item in info.entityType.decodeEnum}
+            if result.registers[offset] not in valid_values:
+                return True
+        return False

--- a/custom_components/victron/hub.py
+++ b/custom_components/victron/hub.py
@@ -94,7 +94,7 @@ class VictronHub:
     def read_holding_registers(self, unit, address, count):
         """Read holding registers."""
         slave = int(unit) if unit else 1
-        _LOGGER.info("Reading unit %s address %s count %s", unit, address, count)
+        _LOGGER.debug("Reading unit %s address %s count %s", unit, address, count)
         return self._client.read_holding_registers(
             address=address, count=count, device_id=slave
         )
@@ -135,29 +135,27 @@ class VictronHub:
                     continue
 
                 try:
-                    address = self.get_first_register_id(register_definition)
-                    count = self.calculate_register_count(register_definition)
-                    result = self.read_holding_registers(unit, address, count)
-                    if result.isError():
-                        _LOGGER.debug(
-                            "result is error for unit: %s address: %s count: %s",
-                            unit,
-                            address,
-                            count,
-                        )
-                    elif self._block_has_undecodable_text(
-                        register_definition, result, address
-                    ):
-                        _LOGGER.debug(
-                            "register set %s on unit %s returned an undecodable "
-                            "text value; treating as not present",
-                            key,
-                            unit,
-                        )
-                    else:
-                        working_registers.append(key)
+                    status = self._probe_block_supported(unit, register_definition)
                 except HomeAssistantError as e:
                     _LOGGER.error(e)
+                    continue
+
+                if status is True:
+                    working_registers.append(key)
+                elif status is False:
+                    _LOGGER.debug(
+                        "register set %s on unit %s returned undecodable text "
+                        "values across all probe attempts; treating as not present",
+                        key,
+                        unit,
+                    )
+                else:
+                    _LOGGER.debug(
+                        "register set %s on unit %s did not respond on any "
+                        "probe attempt; treating as not present",
+                        key,
+                        unit,
+                    )
 
             if len(working_registers) > 0:
                 valid_devices[unit] = working_registers
@@ -166,6 +164,39 @@ class VictronHub:
 
         return valid_devices
 
+    def _probe_block_supported(
+        self, unit, register_definition: OrderedDict, attempts: int = 3
+    ):
+        """Probe a register block multiple times. Tristate result.
+
+        Returns ``True`` if at least one read returned valid (decodable) data,
+        ``False`` if every successful read had undecodable TextReadEntityType
+        values, and ``None`` if every attempt errored or raised. Multi-read
+        consensus prevents a single transient bad value (e.g. a 0xFFFF sentinel
+        emitted briefly during a device reset) from permanently marking a block
+        as not-present, while still pruning blocks that consistently return
+        garbage for registers the hardware does not actually populate.
+        """
+        address = self.get_first_register_id(register_definition)
+        count = self.calculate_register_count(register_definition)
+        saw_undecodable = False
+        for _ in range(attempts):
+            try:
+                result = self.read_holding_registers(unit, address, count)
+            except Exception:  # noqa: BLE001 — bounded retry; transient errors are expected
+                continue
+            if result.isError():
+                continue
+            if self._block_has_undecodable_text(
+                register_definition, result, address
+            ):
+                saw_undecodable = True
+                continue
+            return True
+        if saw_undecodable:
+            return False
+        return None
+
     def _block_has_undecodable_text(
         self, register_definition: OrderedDict, result, first_address: int
     ) -> bool:
@@ -173,8 +204,7 @@ class VictronHub:
 
         Some Victron devices return well-formed Modbus responses with garbage values
         for registers their hardware does not actually populate (e.g. battery_balancer_status
-        on a BMS without a Battery Balancer). Without this check the block is marked
-        present and the resulting entity logs a decode error every poll cycle.
+        on a BMS without a Battery Balancer).
         """
         for info in register_definition.values():
             if not isinstance(info.entityType, TextReadEntityType):


### PR DESCRIPTION
## Problem
`VictronHub.determine_present_devices` treats any non-error Modbus response as proof that a register block is supported by the connected device. Many Victron devices respond successfully with **garbage values** for registers their hardware does not actually populate — for example `battery_balancer_status` (register 1320) on a BMS without a Battery Balancer often returns `0x2D30` (11568), which is well-formed Modbus but not a valid balancer state.

The block then gets marked present, the entity is created, and on every poll cycle `sensor.py` logs:

```
ERROR (MainThread) [custom_components.victron.sensor]
The reported value 11568.0 for entity battery balancer status isn't
a decodable value. Please report this error to the integrations maintainer
```

The user can't dismiss this — the entity exists and the value never enters the enum.

## Fix
After a successful Modbus read in `determine_present_devices`, also validate that any `TextReadEntityType` register in the block actually decodes to a value in its enum. If not, treat the block as not-present and don't create entities for it.

The block-per-register layout in `const.py` (`battery_info_registers` being a single-register block holding only `battery_balancer_status`) was clearly designed for this kind of granular detection — this PR makes the detection actually use it. The check is keyed on the enum definition that already exists in `const.py`, so no new metadata is required.

### Multi-read consensus (review feedback)
Per code review, the validation uses **multi-read consensus** instead of a single-shot decision. `_probe_block_supported` reads each block up to three times and returns:
- `True` if any read decoded successfully → supported, keep
- `False` if every successful read had undecodable text → unsupported, drop
- `None` if every attempt errored or raised → unknown, drop (matches prior behavior on `result.isError()`)

This prevents a transient sentinel (e.g. `0xFFFF` emitted briefly during a device reset) from permanently dropping a block on a device that genuinely supports it. A block has to be *consistently* undecodable to be skipped.

### Folded-in log-level fix
This PR also lowers `read_holding_registers`'s per-call `_LOGGER.info` to `_LOGGER.debug`. With the new multi-read probe (and the auto-revalidation in #442 that builds on it), the per-block read fires multiple times per startup; emitting `info` for each was the source of the original log-flood report. Originally a separate one-line PR (#440), folded in here so #441 doesn't leave an obvious log regression behind.

## Why this is the right layer
- A purely runtime fix in `sensor.py` (mark unavailable / log once) would suppress the symptom but still create a phantom entity that's permanently unavailable.
- A device-class allowlist would require the user to know their hardware topology.
- The detection step already probes Modbus to figure out what's present; extending it to also check that the *content* makes sense is the natural place.

## :warning: Migration note for existing users
`determine_present_devices` only runs during the **config flow**. Its result is then stored in `config_entry.data["registers"]` and the coordinator polls from that stored list, never re-probing. So this PR alone does **not** silence the error for existing installs — they'll continue polling whatever was detected at original setup time.

Existing users have two options:
1. **Remove and re-add the integration** (Settings → Devices & Services → Victron → "..." → Delete, then add it again). The new detection runs on re-add.
2. **PR #442** (stacked on this one) adds an auto-revalidation step in `async_setup_entry` that prunes such blocks at HA startup, fixing existing installs automatically.

## Comparison to existing PRs (#424, #433)
- **#424 / #433** patch `sensor.py` to map the well-known `0xFFFF` (65535) Modbus "unavailable" sentinel to `None`. That handles one specific value.
- **This PR** validates against each register's actual enum, so it catches `0xFFFF`, `0x2D30` (the value reported in this thread), and any other garbage value some BMS firmware returns.
- The two approaches are complementary: this PR prevents phantom entities at setup time; #433-style runtime guards are a safety net for bad reads after setup. If the maintainer wants both, they don't conflict.

## Related issues
This fix is the root-cause resolution for log-spam reports caused by registers in the Victron Modbus map that are not populated by every device:
- #438 victronvebus_microgrid_error227 entity missing — same class of issue once #439 fixes the entity-name bug
- #427 Lynx Shunt VE.Can — likely same pattern

## Supersedes
- #440 (per-read log level: `info` → `debug`) — folded into this PR.

## Test plan
- [x] On a system without a Victron Battery Balancer: `battery_balancer_status` entity is no longer created on a fresh install; the periodic `isn't a decodable value` ERROR is gone.
- [x] On a system that does support a register block (all enum values valid): block is detected as present and entities are created as before.
- [x] Blocks with no `TextReadEntityType` registers behave identically to before (the helper returns `False` for them).
- [x] Per-block reads no longer log at `info` during startup.