### PR TITLE
Re-validate stored register set on startup

### DIFF
--- a/custom_components/victron/__init__.py
+++ b/custom_components/victron/__init__.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 
 from .const import CONF_HOST, CONF_INTERVAL, CONF_PORT, DOMAIN, SCAN_REGISTERS
 from .coordinator import victronEnergyDeviceUpdateCoordinator as Coordinator
+from .hub import VictronHub
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
@@ -19,6 +24,66 @@ PLATFORMS: list[Platform] = [
 ]
 
 
+async def _revalidate_stored_registers(
+    hass: HomeAssistant, config_entry: ConfigEntry
+) -> None:
+    """Heal stored register set against current detection rules at startup.
+
+    Existing config entries can carry register blocks detected before
+    determine_present_devices learned to validate TextReadEntityType
+    contents. Re-probe each stored block (with multi-read consensus in
+    the hub) and drop ones whose text registers consistently fail to
+    decode. Blocks that error on every probe attempt -- e.g. device is
+    transiently unreachable -- are kept in place so a temporary outage
+    cannot wipe a working configuration.
+
+    Wrapped in a broad exception handler: failures here must not break
+    integration startup, since the existing stored config will still
+    serve fine on its own.
+
+    Runs before the update_listener is registered, so the
+    async_update_entry call does not trigger a reload.
+    """
+    stored = config_entry.data.get(SCAN_REGISTERS) or {}
+    if not stored:
+        return
+
+    try:
+        hub = VictronHub(
+            config_entry.options[CONF_HOST], config_entry.options[CONF_PORT]
+        )
+        try:
+            connected = await hass.async_add_executor_job(hub.connect)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Skipping register revalidation: hub.connect raised %s", err
+            )
+            return
+        if not connected:
+            _LOGGER.debug("Skipping register revalidation: hub did not connect")
+            return
+        try:
+            pruned = await hass.async_add_executor_job(
+                hub.revalidate_register_set, stored
+            )
+        finally:
+            try:
+                await hass.async_add_executor_job(hub.disconnect)
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug("Hub disconnect after revalidation raised %s", err)
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.warning(
+            "Register revalidation failed: %s; using stored config", err
+        )
+        return
+
+    if pruned == stored:
+        return
+
+    new_data = {**config_entry.data, SCAN_REGISTERS: pruned}
+    hass.config_entries.async_update_entry(config_entry, data=new_data)
+
+
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Set up victron from a config entry."""
 
@@ -27,6 +92,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     # TODO 2. Validate the API connection (and authentication)
     # TODO 3. Store an API object for your platforms to access
     # hass.data[DOMAIN][entry.entry_id] = MyApi(...)
+
+    await _revalidate_stored_registers(hass, config_entry)
 
     coordinator = Coordinator(
         hass,

--- a/custom_components/victron/hub.py
+++ b/custom_components/victron/hub.py
@@ -197,6 +197,45 @@ class VictronHub:
             return False
         return None
 
+    def revalidate_register_set(self, stored: dict) -> dict:
+        """Re-probe a previously stored register set and prune blocks no longer supported.
+
+        Uses the same multi-read consensus probe as ``determine_present_devices``:
+        a block is dropped only if every successful read returns undecodable
+        TextReadEntityType values. Blocks that error on every attempt (e.g.
+        device temporarily unreachable) are kept in place -- this revalidation
+        runs at HA startup and a transient outage must not wipe a working
+        configuration.
+
+        Existing config entries can carry register blocks that were detected
+        before ``determine_present_devices`` learned to validate
+        TextReadEntityType contents; this lets ``async_setup_entry`` heal them
+        at startup without requiring users to re-add the integration.
+        """
+        pruned: dict = {}
+        for unit, blocks in stored.items():
+            kept = []
+            for key in blocks:
+                register_definition = register_info_dict.get(key)
+                if register_definition is None:
+                    # Block no longer exists in the integration; drop it.
+                    continue
+                status = self._probe_block_supported(unit, register_definition)
+                if status is False:
+                    _LOGGER.info(
+                        "Pruning register block %s on unit %s: text register "
+                        "no longer decodes against its enum across all probe "
+                        "attempts",
+                        key,
+                        unit,
+                    )
+                    continue
+                # status is True (supported) or None (transient error) -- keep.
+                kept.append(key)
+            if kept:
+                pruned[unit] = kept
+        return pruned
+
     def _block_has_undecodable_text(
         self, register_definition: OrderedDict, result, first_address: int
     ) -> bool:

--- a/custom_components/victron/hub.py
+++ b/custom_components/victron/hub.py
@@ -15,6 +15,7 @@ from .const import (
     INT32,
     INT64,
     STRING,
+    TextReadEntityType,
     UINT16,
     UINT32,
     UINT64,
@@ -144,6 +145,15 @@ class VictronHub:
                             address,
                             count,
                         )
+                    elif self._block_has_undecodable_text(
+                        register_definition, result, address
+                    ):
+                        _LOGGER.debug(
+                            "register set %s on unit %s returned an undecodable "
+                            "text value; treating as not present",
+                            key,
+                            unit,
+                        )
                     else:
                         working_registers.append(key)
                 except HomeAssistantError as e:
@@ -155,3 +165,24 @@ class VictronHub:
                 _LOGGER.debug("no registers found for unit: %s", unit)
 
         return valid_devices
+
+    def _block_has_undecodable_text(
+        self, register_definition: OrderedDict, result, first_address: int
+    ) -> bool:
+        """Return True if any TextReadEntityType register in the block decodes outside its enum.
+
+        Some Victron devices return well-formed Modbus responses with garbage values
+        for registers their hardware does not actually populate (e.g. battery_balancer_status
+        on a BMS without a Battery Balancer). Without this check the block is marked
+        present and the resulting entity logs a decode error every poll cycle.
+        """
+        for info in register_definition.values():
+            if not isinstance(info.entityType, TextReadEntityType):
+                continue
+            offset = info.register - first_address
+            if offset < 0 or offset >= len(result.registers):
+                continue
+            valid_values = {item.value for item in info.entityType.decodeEnum}
+            if result.registers[offset] not in valid_values:
+                return True
+        return False

--- a/custom_components/victron/hub.py
+++ b/custom_components/victron/hub.py
@@ -94,7 +94,7 @@ class VictronHub:
     def read_holding_registers(self, unit, address, count):
         """Read holding registers."""
         slave = int(unit) if unit else 1
-        _LOGGER.info("Reading unit %s address %s count %s", unit, address, count)
+        _LOGGER.debug("Reading unit %s address %s count %s", unit, address, count)
         return self._client.read_holding_registers(
             address=address, count=count, device_id=slave
         )
@@ -135,29 +135,27 @@ class VictronHub:
                     continue
 
                 try:
-                    address = self.get_first_register_id(register_definition)
-                    count = self.calculate_register_count(register_definition)
-                    result = self.read_holding_registers(unit, address, count)
-                    if result.isError():
-                        _LOGGER.debug(
-                            "result is error for unit: %s address: %s count: %s",
-                            unit,
-                            address,
-                            count,
-                        )
-                    elif self._block_has_undecodable_text(
-                        register_definition, result, address
-                    ):
-                        _LOGGER.debug(
-                            "register set %s on unit %s returned an undecodable "
-                            "text value; treating as not present",
-                            key,
-                            unit,
-                        )
-                    else:
-                        working_registers.append(key)
+                    status = self._probe_block_supported(unit, register_definition)
                 except HomeAssistantError as e:
                     _LOGGER.error(e)
+                    continue
+
+                if status is True:
+                    working_registers.append(key)
+                elif status is False:
+                    _LOGGER.debug(
+                        "register set %s on unit %s returned undecodable text "
+                        "values across all probe attempts; treating as not present",
+                        key,
+                        unit,
+                    )
+                else:
+                    _LOGGER.debug(
+                        "register set %s on unit %s did not respond on any "
+                        "probe attempt; treating as not present",
+                        key,
+                        unit,
+                    )
 
             if len(working_registers) > 0:
                 valid_devices[unit] = working_registers
@@ -166,6 +164,39 @@ class VictronHub:
 
         return valid_devices
 
+    def _probe_block_supported(
+        self, unit, register_definition: OrderedDict, attempts: int = 3
+    ):
+        """Probe a register block multiple times. Tristate result.
+
+        Returns ``True`` if at least one read returned valid (decodable) data,
+        ``False`` if every successful read had undecodable TextReadEntityType
+        values, and ``None`` if every attempt errored or raised. Multi-read
+        consensus prevents a single transient bad value (e.g. a 0xFFFF sentinel
+        emitted briefly during a device reset) from permanently marking a block
+        as not-present, while still pruning blocks that consistently return
+        garbage for registers the hardware does not actually populate.
+        """
+        address = self.get_first_register_id(register_definition)
+        count = self.calculate_register_count(register_definition)
+        saw_undecodable = False
+        for _ in range(attempts):
+            try:
+                result = self.read_holding_registers(unit, address, count)
+            except Exception:  # noqa: BLE001 — bounded retry; transient errors are expected
+                continue
+            if result.isError():
+                continue
+            if self._block_has_undecodable_text(
+                register_definition, result, address
+            ):
+                saw_undecodable = True
+                continue
+            return True
+        if saw_undecodable:
+            return False
+        return None
+
     def _block_has_undecodable_text(
         self, register_definition: OrderedDict, result, first_address: int
     ) -> bool:
@@ -173,8 +204,7 @@ class VictronHub:
 
         Some Victron devices return well-formed Modbus responses with garbage values
         for registers their hardware does not actually populate (e.g. battery_balancer_status
-        on a BMS without a Battery Balancer). Without this check the block is marked
-        present and the resulting entity logs a decode error every poll cycle.
+        on a BMS without a Battery Balancer).
         """
         for info in register_definition.values():
             if not isinstance(info.entityType, TextReadEntityType):


### PR DESCRIPTION
## Summary
Follow-up to #441. That PR teaches `determine_present_devices` to drop register blocks whose `TextReadEntityType` registers return values outside their decode enum (i.e. the device doesn't actually populate the register). But `determine_present_devices` only runs during the **config flow** — its result is then frozen in `config_entry.data["registers"]` and the coordinator polls from that stored list, never re-probing.

This PR closes that gap: at `async_setup_entry` time, before the coordinator starts, re-probe each stored register block once and prune any whose text registers no longer decode. The pruned list is persisted back to the config entry. Existing installs heal automatically on the next HA restart; users do not need to remove and re-add the integration.

## Stacked on #441
This branches off #441 and uses its `_probe_block_supported` helper. Please merge #441 first.

## Address review feedback (force-pushed)
The original revision of this PR had three issues called out in code review. All addressed in the rebased branch:

### 1. Single-read pruning was unsafe at revalidation time (Copilot)
Re-probing a previously-working block once and dropping it on the first bad read meant that a transient `0xFFFF` sentinel during a device reset could permanently wipe valid entities. **Now** revalidation goes through the same `_probe_block_supported` helper added in #441 — multi-read consensus, three attempts. A block is only pruned when text registers fail to decode on **every** successful read; transient errors keep the block in place.

### 2. Log noise from the extra read pass (Copilot)
The original PR stacked on #441 but not #440 (per-read log level). With `read_holding_registers` still at `info`, the revalidation pass roughly doubled the startup log flood. **Now** the log-level change is folded into #441, so as long as #441 lands first this PR no longer adds noise.

### 3. `connect()` raising vs. returning False (Copilot)
The original `try/finally` only handled `connect()` returning `False`. If `ModbusTcpClient.connect()` raised, the exception propagated out of `async_setup_entry` and broke integration startup. **Now** `_revalidate_stored_registers` wraps the entire body in a broad `except Exception`: any unexpected failure (connect raising, transient probe error, write-back error) leaves the stored config alone and lets `async_setup_entry` continue with the existing data. The principle is: revalidation is a best-effort heal, never a path that can break startup.

## Failure modes (defensive by design)
- **Hub fails to connect (returns False or raises)**: skip revalidation, leave stored config alone, log at debug/warning.
- **Multi-read probe inconclusive on a block**: keep the block — better to leave a possibly-stale block in place than to drop a working one.
- **Unexpected exception anywhere in the body**: log warning, leave stored config alone.

## Why this layer
The revalidation runs **before** `config_entry.add_update_listener(update_listener)` is registered, so the `async_update_entry` call doesn't trigger a reload loop.

The integration also doesn't expose a "manual rescan" UI today, so users on existing installs have no in-band way to apply the new validation rules. Auto-healing on startup is the lowest-friction option.

## Test plan
- [x] Existing install with `battery_info_registers` stored from a pre-#441 setup: after one restart, the block is pruned, the entity is removed, the periodic decode-error log goes away. *(Verified on a real installation with a Victron BMS that does not have a Battery Balancer.)*
- [x] System without the issue: nothing changes; `pruned == stored` short-circuits the persist.
- [x] Modbus disconnected at startup: revalidation skipped early, coordinator behaves as before.
- [x] Single block returns Modbus error: kept (would be a regression if dropped).
- [x] Single transient bad read followed by a good read: block kept (multi-read consensus).

## Note
Independent of #439 (entityType= keyword fix). Stacked on #441 (which now also folds in the former #440).