### PR TITLE
Fix non-serializable unit on vebus_microgrid entities crashing recorder statistics

### DIFF
--- a/custom_components/victron/const.py
+++ b/custom_components/victron/const.py
@@ -163,6 +163,15 @@ class RegisterInfo:
         """Initialize the register info."""
         self.register = register
         self.dataType = dataType
+        if isinstance(unit, EntityType):
+            # An EntityType was passed positionally into the unit slot.
+            # Recover it as the entityType so the unit never ends up as a
+            # non-serializable object, which crashes the HA websocket and
+            # aborts every recorder StatisticsTask run (issue #444).
+            entityType = unit
+            unit = None
+        elif not isinstance(unit, str):
+            unit = None
         self.unit = (
             unit
             if not isinstance(entityType, TextReadEntityType)
@@ -722,10 +731,10 @@ class microgrid_error(Enum):
 
 vebus_registers_4 = {
     "vebus_microgrid_heartbeat": RegisterInfo(
-        230, UINT16, 1, entityType=ButtonWriteType()
+        register=230, dataType=UINT16, entityType=ButtonWriteType()
     ),
     "vebus_microgrid_error": RegisterInfo(
-        231, UINT16, TextReadEntityType(microgrid_error)
+        register=231, dataType=UINT16, entityType=TextReadEntityType(microgrid_error)
     ),
 }
 


### PR DESCRIPTION
## Problem

`vebus_microgrid_error` (register 231, `vebus_registers_4`) passes `TextReadEntityType(microgrid_error)` **positionally into the `unit` slot** of `RegisterInfo`, and `vebus_microgrid_heartbeat` (register 230) passes the integer `1` the same way. The existing guard in `RegisterInfo.__init__` only checks the `entityType` keyword, so the entity ends up with a non-string `unit_of_measurement`.

The consequences (see #444, and #438 which this likely also explains):

- The HA websocket cannot serialize the state → frontend errors, entity invisible in the UI
- Worse: **every recorder `StatisticsTask` run aborts** on the `statistics_meta` INSERT (`sqlite3.ProgrammingError: type 'TextReadEntityType' is not supported`), which halts long-term statistics **for the entire HA instance** — the Energy dashboard silently stops recording. Confirmed on v0.6.4 + HA 2026.7.2 (3x Quattro-II three-phase, VE.Bus unit 227): one crash every 5 minutes, statistics frozen for 13+ hours until the entity was disabled. The gap is not backfilled after restart, so the data loss is permanent.

## Fix

1. **`vebus_registers_4`**: register both entities with the `entityType` keyword. As a bonus `vebus_microgrid_error` now actually decodes its enum values (`NO_ERROR`, …) as intended, matching the `vebus_error` pattern.
2. **`RegisterInfo.__init__`**: normalize the `unit` argument — an `EntityType` passed positionally is recovered as the `entityType`, and any other non-string unit is dropped to `None`. This keeps a future registration mistake of the same class from ever reaching the recorder again. With `unit=None`, `determine_stateclass()` correctly returns no state class for these text/button entities.

Backwards compatible: no entity IDs change; the two affected entities lose their bogus unit (`TextReadEntityType` object / `1`) and their incorrect `measurement` state class.

## Testing

- Reproduced the recorder crash extensively on a live three-phase system (traceback in #444 comment) and confirmed the instance recovers as soon as the offending entity stops reporting.
- `python -m py_compile` passes; happy to report back after running this patch on our system, and to adjust if you prefer a different guard placement (e.g. the `sensor.py` one-liner proposed in #444).

Fixes #444
