### PR TITLE
Fix TypeError: bool object can't be awaited during reconfigure

### DIFF
--- a/custom_components/victron/config_flow.py
+++ b/custom_components/victron/config_flow.py
@@ -250,7 +250,7 @@ class VictronFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             try:
                 hub = VictronHub(user_input[CONF_HOST], user_input[CONF_PORT])
-                await hub.connect()
+                hub.connect()
                 _LOGGER.info("connection was succesfull")
             except HomeAssistantError as e:
                 errors["base"] = f"cannot_connect ({e!s})"


### PR DESCRIPTION
Fixing issue #449. Confirmed working on my local instance. See full details in the issue report.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
hub.connect() in hub.py is a synchronous method returning a bool. config_flow.py line 253 incorrectly awaited it, causing a TypeError during reconfigure. Removed the await to match the existing pattern used in validate_input(). This is consistent with validate_input() around line 73.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #449 
- This PR is related to issue: #449 
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] The code has been formatted using Ruff (`ruff format custom_components/victron`)
