### PR TITLE
Fix missing entityType keyword arg for vebus_microgrid_error register

### DIFF
--- a/custom_components/victron/const.py
+++ b/custom_components/victron/const.py
@@ -725,7 +725,7 @@ vebus_registers_4 = {
         230, UINT16, 1, entityType=ButtonWriteType()
     ),
     "vebus_microgrid_error": RegisterInfo(
-        231, UINT16, TextReadEntityType(microgrid_error)
+        231, UINT16, entityType=TextReadEntityType(microgrid_error)
     ),
 }
 


### PR DESCRIPTION
## What
Adds the missing `entityType=` keyword argument when constructing the `vebus_microgrid_error` register.

## Why
`RegisterInfo.__init__` has the signature `(register, dataType, unit="", scale=1, entityType=ReadEntityType(), step=0)`. The `vebus_microgrid_error` entry called it positionally:

```python
"vebus_microgrid_error": RegisterInfo(
    231, UINT16, TextReadEntityType(microgrid_error)
),
```

The third positional argument binds to `unit`, not `entityType`. This leaves `entityType` at its default (`ReadEntityType()`), while `unit` ends up holding a raw `TextReadEntityType` Python object instead of a string/`None`.

## Impact
Because `unit` (exposed as the sensor's `native_unit_of_measurement`) is a non-JSON-serializable Python object, `sensor.victron{...}vebus_microgrid_error{unit}` breaks:

- Every call to Home Assistant's `/api/states` endpoint (bulk state list) raises:
  ```
  TypeError: Type is not JSON serializable: TextReadEntityType
  ```
  causing repeated `aiohttp.server` errors — thousands of occurrences over a few hours on an affected instance.
- The recorder's `state_attributes` writer logs `State is not JSON serializable` warnings for this entity on every update.
- Long-term statistics generation for this entity is suppressed (`unit ... cannot be converted to the unit of previously compiled statistics`).

## Fix
Add the missing `entityType=` keyword so the argument binds correctly:

```python
"vebus_microgrid_error": RegisterInfo(
    231, UINT16, entityType=TextReadEntityType(microgrid_error)
),
```

This is the only occurrence of this bug pattern in `const.py` (verified via `grep -nE '^\s*[0-9]+,\s*[A-Za-z0-9_]+,\s*(Text|Bool)?ReadEntityType\('` across the whole file).

## Testing
Verified on a live Home Assistant instance running this integration:
- Before the fix: `GET /api/states` returned HTTP 500 with the traceback above, repeating on every poll interval.
- After the fix (patched + core restarted): `GET /api/states` returns 200, `sensor.victron...vebus_microgrid_error...` reports its decoded state (e.g. `NO_ERROR`) with no `unit_of_measurement` attribute, and the error no longer appears in the log.