### PR TITLE
Fix deprecated CONCENTRATION_* constants (use UnitOfDensity/UnitOfRatio)

### DIFF
--- a/custom_components/victron/const.py
+++ b/custom_components/victron/const.py
@@ -4,11 +4,10 @@ from enum import Enum
 
 from homeassistant.components.sensor import SensorStateClass
 from homeassistant.const import (
-    CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-    CONCENTRATION_PARTS_PER_MILLION,
     LIGHT_LUX,
     PERCENTAGE,
     REVOLUTIONS_PER_MINUTE,
+    UnitOfDensity,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfEnergy,
@@ -17,6 +16,7 @@ from homeassistant.const import (
     UnitOfLength,
     UnitOfPower,
     UnitOfPressure,
+    UnitOfRatio,
     UnitOfSpeed,
     UnitOfTemperature,
     UnitOfTime,
@@ -2097,11 +2097,11 @@ temperature_registers = {
 }
 
 temperature_registers_2 = {
-    "temperature_co2": RegisterInfo(3309, UINT16, CONCENTRATION_PARTS_PER_MILLION, 1),
+    "temperature_co2": RegisterInfo(3309, UINT16, UnitOfRatio.PARTS_PER_MILLION, 1),
     "temperature_lux": RegisterInfo(3310, UINT32, LIGHT_LUX, 1),
     "temperature_nitrogen_oxides": RegisterInfo(3312, UINT16, "", 1),
     "temperature_particulate_matter": RegisterInfo(
-        3313, UINT16, CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, 1
+        3313, UINT16, UnitOfDensity.MICROGRAMS_PER_CUBIC_METER, 1
     ),
     "temperature_volatile_organic_compounds": RegisterInfo(3314, UINT16, "", 1),
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #459 

Replaces the deprecated `CONCENTRATION_MICROGRAMS_PER_CUBIC_METER` and
`CONCENTRATION_PARTS_PER_MILLION` constants with their `UnitOfDensity` /
`UnitOfRatio` equivalents, ahead of removal in HA Core 2027.8.

No functional change — same units, just the current constant names.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #459 
- This PR is related to issue:
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] There is no commented out code in this PR.
- [ ] The code has been formatted using Ruff (`ruff format custom_components/victron`)
